### PR TITLE
feat(ci): switch release workflow to GitHub App for bypass

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,8 +40,15 @@ jobs:
       - name: Build
         run: bun run build
 
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: bunx semantic-release


### PR DESCRIPTION
Resolves #27

This PR updates the release workflow to use a GitHub App token for committing the version bump and changelog to the protected `main` branch.

**Setup Required:**
You must configure the following repository secrets:
- `RELEASE_APP_ID`: The App ID of the GitHub App.
- `RELEASE_APP_PRIVATE_KEY`: The private key of the GitHub App.

The GitHub App must have `contents: write` and `pull-requests: write` permissions on the repository.