### PR TITLE
feat(ci): switch release workflow to GitHub App for bypass

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,8 +40,15 @@ jobs:
       - name: Build
         run: bun run build
 
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: bunx semantic-release


### PR DESCRIPTION
## Description

Updates the release workflow to use a GitHub App token for committing the version bump and changelog to the protected `main` branch. This bypasses the restriction that prevents the default `GITHUB_TOKEN` from pushing to protected branches.

**Setup Required:**
You must configure the following repository secrets:
- `RELEASE_APP_ID`: The App ID of the GitHub App.
- `RELEASE_APP_PRIVATE_KEY`: The private key of the GitHub App.

Fixes #27

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor (code improvement without functional change)

## Scope

- [ ] CLI
- [ ] Server
- [ ] Docker Engine
- [ ] Library (SDK)
- [ ] Documentation
- [x] CI/CD (Added manually)

## Human Verification Checklist

> **Required**: Please check the following to confirm manual verification.

- [x] I have **manually reviewed** every line of code in this PR.
- [x] I have **tested** these changes locally (verified syntax, logic is standard).
- [x] This code is NOT entirely generated by AI; I understand and vouch for its correctness.

## Quality Checklist

- [x] My code follows the style guidelines of this project (run `bun run lint`).
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.