### PR TITLE
test(workflow): remove invalid 'needs' at step level

### DIFF
--- a/.github/workflows/production-test.yml
+++ b/.github/workflows/production-test.yml
@@ -61,8 +61,7 @@ jobs:
           ISOL8_TEST_VERSION: ${{ github.event.inputs.version }}
 
       - name: Run performance benchmarks
-        needs: tests
-        if: github.event.inputs.runBenchmarks == 'true' && needs.tests.outputs.failed == '0'
+        if: github.event.inputs.runBenchmarks == 'true' && steps.tests.outputs.failed == '0'
         run: |
           echo ""
           echo "=========================================="


### PR DESCRIPTION
## Description

Fixes GitHub Actions workflow validation error:
```
(Line: 64, Col: 9): Unexpected value 'needs'
```

The `needs` keyword is only valid at **job level** (to define dependencies between jobs), not at the **step level**. This was incorrectly placed on the "Run performance benchmarks" step.

## Changes

- Remove `needs: tests` from line 64
- Change `needs.tests.outputs.failed` to `steps.tests.outputs.failed` to correctly reference the previous step's output in the same job

## Testing

Workflow syntax validated - should now pass GitHub Actions validation.