### PR TITLE
feat: default root filesystem to read-only, remove the --writable CLI flag, and add new documentation guides

### DIFF
--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -80,10 +80,6 @@ isol8 run [file] [options]
   Maximum number of processes.
 </ResponseField>
 
-<ResponseField name="--writable" type="flag">
-  Disables read-only rootfs (`readonlyRootFs=false`).
-</ResponseField>
-
 <ResponseField name="--max-output <bytes>" type="number" default="1048576">
   Maximum output size before truncation.
 </ResponseField>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -110,6 +110,7 @@
           {
             "group": "Application Patterns",
             "pages": [
+              "guides/persistent-execution",
               "guides/ai-agents",
               "guides/data-processing",
               "guides/web-scraping",

--- a/docs/file-systems.mdx
+++ b/docs/file-systems.mdx
@@ -29,17 +29,6 @@ Any attempt to write outside of the designated `tmpfs` mounts will result in an 
 In certain use cases (e.g., legacy workloads or specific compilation tasks), you might need a globally writable file system. You can disable the read-only restriction, but this is **highly discouraged** for untrusted code execution.
 
 <Tabs>
-  <Tab title="CLI">
-    Use the `--writable` flag to make the root file system writable.
-    <CodeGroup>
-    ```bash Command
-    isol8 execute python --code "open('/writable.txt', 'w').write('test')" --writable
-    ```
-    ```text Expected behavior
-    The script successfully creates /writable.txt in the container root without throwing a read-only error.
-    ```
-    </CodeGroup>
-  </Tab>
   <Tab title="Library">
     Set `readonlyRootFs: false` in your configuration.
     <CodeGroup>
@@ -58,6 +47,16 @@ In certain use cases (e.g., legacy workloads or specific compilation tasks), you
     ```
     </CodeGroup>
   </Tab>
+  <Tab title="Config">
+    Set `readonlyRootFs: false` under the `defaults` section in `isol8.config.json` to apply it to all executions.
+    ```json isol8.config.json
+    {
+      "defaults": {
+        "readonlyRootFs": false
+      }
+    }
+    ```
+  </Tab>
 </Tabs>
 
 <Warning>
@@ -71,6 +70,12 @@ Even with a read-only root, agents and scripts often need temporary space to wri
 A `tmpfs` mount resides entirely in host RAM (or swap space) rather than on disk. This provides two major benefits:
 1. **Speed**: File I/O operations in these directories are significantly faster than disk-backed storage.
 2. **Ephemeral Guarantees**: When the container is destroyed, the contents of the `tmpfs` mounts vanish instantly. There is zero risk of data persistence across executions.
+
+### Ephemeral vs Persistent Mode Behavior
+
+The lifecycle of files within `tmpfs` mounts depends entirely on your execution mode:
+- **Ephemeral mode**: Files written to `/sandbox` or `/tmp` are destroyed immediately when the execution request completes and the container is recycled.
+- **Persistent mode**: Files remain intact inside the `tmpfs` mounts across multiple execution requests as long as the same container session remains active. The contents are only destroyed when the session is explicitly stopped or pruned due to inactivity.
 
 `isol8` provisions two default `tmpfs` mounts:
 

--- a/docs/guides/lambda-alternative.mdx
+++ b/docs/guides/lambda-alternative.mdx
@@ -1,0 +1,156 @@
+---
+title: "Self-Hosted Lambda Alternative"
+description: "Use isol8 as a high-performance, secure, and low-cost alternative to AWS Lambda for executing untrusted code."
+icon: "lambda"
+---
+
+`isol8` provides all the core primitives of a serverless execution environment—API gateway, isolated sandboxes, warm container pools, and resource throttling—allowing you to build a self-hosted alternative to AWS Lambda. 
+
+Unlike AWS Lambda, `isol8` offers lower latency through warm pools, built-in network egress filtering, and the ability to maintain state across calls via persistent sessions.
+
+## Mapping Lambda to isol8
+
+If you are coming from AWS Lambda, here is how the concepts map to `isol8` features:
+
+| AWS Lambda Concept | isol8 Equivalent | Why it's better |
+| :--- | :--- | :--- |
+| **API Gateway** | `isol8 serve` | Single binary, no complex VPC/IAM setup. |
+| **MicroVM (Firecracker)** | **Hardened Docker** | Similar isolation with better runtime compatibility. |
+| **Warm Starts** | `ContainerPool` | Sub-100ms "cold starts" with `fast` pool strategy. |
+| **Lambda Layers** | `isol8 setup` | Pre-bake dependencies into custom Docker images. |
+| **VPC Egress Rules** | **Network Filtering** | Regex-based whitelisting for HTTP(S) traffic. |
+| **IAM Auth** | **Bearer Token** | Simple, secure API key authentication. |
+
+## Core Architecture
+
+A self-hosted Lambda setup with `isol8` consists of three main components:
+
+```mermaid
+flowchart TD
+  Client["RemoteIsol8 Client"] -- "REST API (Bearer Auth)" --> Gateway["isol8 serve (Gateway)"]
+  Gateway -- "Semaphore Control" --> Engine["Isol8 Engine"]
+  Engine -- "Acquire" --> Pool["Warm Container Pool"]
+  Pool -- "Execute" --> Sandbox["Hardened Sandbox"]
+  
+  subgraph Sandbox ["Hardened Sandbox"]
+    Code["Untrusted Code"]
+    Proxy["Egress Proxy"]
+    Code -- "Filtered Traffic" --> Proxy
+  end
+```
+
+## Setup Guide
+
+Follow these steps to deploy your own Lambda-like execution service.
+
+<Steps>
+  <Step title="Configure the Engine">
+    Create an `isol8.config.json` to define your "Lambda" defaults and security boundaries.
+
+    ```json
+    {
+      "maxConcurrent": 20,
+      "poolStrategy": "fast",
+      "poolSize": { "clean": 5, "dirty": 5 },
+      "defaults": {
+        "timeoutMs": 30000,
+        "memoryLimit": "512m",
+        "cpuLimit": 1.0,
+        "network": "filtered"
+      },
+      "network": {
+        "whitelist": ["^api\.openai\.com$", ".*\.pypi\.org$"]
+      }
+    }
+    ```
+  </Step>
+
+  <Step title="Pre-bake Dependencies">
+    Instead of installing packages during every execution (which causes high latency), pre-build your runtimes with the libraries your "Functions" will need:
+
+    ```bash
+    isol8 setup --python numpy,pandas,requests --node lodash,axios
+    ```
+  </Step>
+
+  <Step title="Start the API Gateway">
+    Run the server using the standalone binary or `npx`. This provides the execution endpoint for your clients.
+
+    ```bash
+    isol8 serve --port 3000 --key your-secret-api-key
+    ```
+  </Step>
+
+  <Step title="Invoke from a Client">
+    Use the `RemoteIsol8` client to "invoke" your function from any application.
+
+    ```typescript
+    import { RemoteIsol8 } from "isol8";
+
+    const isol8 = new RemoteIsol8({
+      host: "http://your-server-ip:3000",
+      apiKey: "your-secret-api-key"
+    });
+
+    const result = await isol8.execute({
+      code: "print('Hello from my self-hosted Lambda!')",
+      runtime: "python"
+    });
+    ```
+  </Step>
+</Steps>
+
+## Key Execution Patterns
+
+### 1. Ephemeral (Pure Lambda)
+Each request gets a fresh container from the warm pool. Once the execution finishes, the container is returned for cleanup and the next request starts from a blank slate. This is the default behavior.
+
+### 2. Stateful (Session-based)
+Unlike AWS Lambda, `isol8` supports stateful sessions. If you pass a `sessionId`, the execution happens in a persistent container. Files written to `/sandbox` or packages installed during the run will be available for the next call with the same `sessionId`.
+
+### 3. Real-time Streaming
+For AI agent workflows, you can stream stdout/stderr in real-time via Server-Sent Events (SSE) using the `executeStream()` method, allowing your UI to show progress immediately.
+
+## Performance Tuning
+
+To minimize latency and maximize throughput:
+
+*   **Warm Pool Size**: Increase `poolSize.clean` if you expect bursts of traffic.
+*   **Concurrency**: Set `maxConcurrent` to match your server's CPU/RAM capacity.
+*   **Memory Limits**: Lower `memoryLimit` for simple tasks to allow more parallel containers on the same host.
+
+## Security Best Practices
+
+<Warning>
+  When running untrusted code, always use `network: "filtered"` or `network: "none"` to prevent data exfiltration.
+</Warning>
+
+*   **Mask Secrets**: Use the `secrets` option to pass API keys to the sandbox; `isol8` will automatically scrub these values from the stdout/stderr output.
+*   **ReadOnly Root**: Keep `readonlyRootFs: true` enabled to prevent code from modifying the system binaries or configuration inside the container.
+*   **Seccomp**: Use the default `strict` seccomp profile to block dangerous kernel operations.
+
+## FAQ
+
+<Accordion title="How much does it cost?">
+  The software is MIT licensed and free. Your only cost is the hosting for your Docker server (e.g., a $5/mo VPS can easily handle hundreds of daily executions).
+</Accordion>
+
+<Accordion title="Does it support automatic scaling?">
+  `isol8` manages internal concurrency and pooling. For horizontal scaling across multiple servers, you can place a standard load balancer (like Nginx or HAProxy) in front of multiple `isol8 serve` instances.
+</Accordion>
+
+## Troubleshooting
+
+### High Latency on First Run
+**Symptom**
+- The first execution after startup takes 2-3 seconds.
+
+**Fix**
+- This is a "Cold Start." Ensure you run `isol8 setup` beforehand to build the images, and consider increasing the `poolSize` so containers are pre-warmed and ready before the first request arrives.
+
+### Package Install Failures
+**Symptom**
+- `--install` fails with "Permission denied" or "Read-only file system."
+
+**Fix**
+- Runtimes like Python and Node require specific environment variables to install to the writable `/sandbox` directory. `isol8` sets these automatically, but ensure you aren't overriding the `PYTHONUSERBASE` or `NPM_CONFIG_PREFIX` in your `ExecutionRequest.env`.

--- a/docs/guides/persistent-execution.mdx
+++ b/docs/guides/persistent-execution.mdx
@@ -1,0 +1,134 @@
+---
+title: "Persistent execution guide"
+description: "How to run persistent containers and interact with them repeatedly via Library, CLI, and API."
+icon: "database"
+---
+
+`isol8` operates in an ephemeral mode by default, tearing down the container after a single execution to ensure absolute isolation. However, many use cases require state to be maintained across multiple execution calls. 
+
+This guide details how to keep a persistent container alive and continue to execute commands within the same environment across the Library, CLI, and API.
+
+## Library
+
+When using the `DockerIsol8` engine directly, persistent mode is straightforward. The lifecycle of the container is intrinsically tied to the lifecycle of the engine instance. 
+
+To reuse the same container runtime environment:
+1. Initialize the engine with `mode: "persistent"`.
+2. Start the engine explicitly (so it provisions the container).
+3. Execute as many commands as needed.
+4. Stop the engine to tear down the persistent container.
+
+<CodeGroup>
+```typescript Input
+import { DockerIsol8 } from "isol8";
+
+// 1. Initialize persistent engine
+const isol8 = new DockerIsol8({ mode: "persistent" });
+
+try {
+  // 2. Start the engine (creates the persistent container)
+  await isol8.start();
+
+  // 3. First execution sets up state
+  await isol8.execute({ 
+    code: "x = 40", 
+    runtime: "python" 
+  });
+
+  // 3. Second execution reuses state
+  const result = await isol8.execute({ 
+    code: "print(x + 2)", 
+    runtime: "python" 
+  });
+
+  console.log(result.stdout);
+} finally {
+  // 4. Tear down the persistent container
+  await isol8.stop();
+}
+```
+
+```text Expected output
+42
+```
+</CodeGroup>
+
+<Note>
+Persistent containers are runtime-bound because `isol8` provisions a specific image (e.g., Python, Node) when starting the engine. You cannot execute bash, then python, within the same persistent session.
+</Note>
+
+## Command Line Interface (CLI)
+
+The CLI is generally designed for single, synchronous executions. However, you can use the `--persistent` flag to tell `isol8 run` to operate over a persistent container.
+
+By default, the CLI will still stop and clean up the container once the single command completes, as the `isol8` process itself terminates. 
+
+### Leaving a container running (`--persist` vs `--persistent`)
+
+If you want to spin up a container and manually inspect it later or connect to it with `docker exec`, you can use the `--persist` flag.
+
+- **`--persistent`**: Sets the execution engine mode to "persistent" (reusing the same filesystem/packages during runs, but the container still stops when the CLI exits).
+- **`--persist`**: Tells `isol8` *not* to stop the container when the execution finishes.
+
+```bash
+isol8 run --persistent --persist -e "x = 42" --runtime python
+```
+
+The CLI will print the container ID upon start and heavily rely on `isol8 cleanup` to remove it later, or you can attach to it via bash. But keeping a container alive continuously to receive *subsequent* CLI commands is not supported unless passing through the **Server API**.
+
+## Server API
+
+If you are running the `isol8 serve` server, persistent execution is driven entirely by the `sessionId` concept. When a `sessionId` is provided in an API request, the server automatically infers persistent mode and ties the container lifecycle to that ID.
+
+### 1. Initiate a Persistent Session
+
+Simply send your first payload with an arbitrary unique `sessionId`. The server will create the container, execute the code, and leave the container running.
+
+```bash
+curl -X POST http://localhost:3000/execute \
+  -H "Authorization: Bearer $ISOL8_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "sessionId": "agent-session-123",
+    "request": {
+      "code": "history = []",
+      "runtime": "python"
+    }
+  }'
+```
+
+### 2. Follow-up Executions
+
+Use the exact same `sessionId` to execute code within the same container environment.
+
+```bash
+curl -X POST http://localhost:3000/execute \
+  -H "Authorization: Bearer $ISOL8_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "sessionId": "agent-session-123",
+    "request": {
+      "code": "history.append(\"first action\"); print(history)",
+      "runtime": "python"
+    }
+  }'
+```
+
+### 3. Cleanup the Session
+
+Persistent sessions consume system resources (RAM, tmpfs mounts, Docker daemon capabilities). You must explicitly clean up the session using the `DELETE` endpoint once you are done.
+
+```bash
+curl -X DELETE http://localhost:3000/session/agent-session-123 \
+  -H "Authorization: Bearer $ISOL8_API_KEY"
+```
+
+<Note>
+The server also provides an automatic pruning mechanism. If a persistent session sits idle (no execution or file requests) for longer than `cleanup.maxContainerAgeMs` (default 1 hour), it is aggressively cleaned up by the server's background worker.
+</Note>
+
+## When to use Persistent Mode
+
+- ✅ **Iterative Workloads**: Tasks like data scraping, where a browser/puppeteer environment takes seconds to initialize, but subsequent scraper commands are very fast.
+- ✅ **Stateful Code Generation**: When an LLM agent writes a script incrementally, runs it, parses the error, and adjusts variables in the subsequent run.
+- ❌ **One-Off Transformations**: Parsing a JSON blob or compiling a single stylesheet. Ephemeral containers are faster for independent runs since they operate out of a pre-warmed pool.

--- a/docs/option-mapping.mdx
+++ b/docs/option-mapping.mdx
@@ -272,7 +272,7 @@ These are engine/runtime behavior options (constructor options locally, `options
 </ResponseField>
 
 <ResponseField name="readonlyRootFs" type="boolean" default="true">
-  **CLI**: `--writable` sets `readonlyRootFs=false`.
+  **CLI**: no direct `run` flag.
 
   **Config**: no direct key.
 

--- a/docs/security.mdx
+++ b/docs/security.mdx
@@ -26,7 +26,7 @@ Out of the box, executions run with:
 | Filter deny rules | `--deny` | `network.blacklist` | `options.networkFilter.blacklist` | `networkFilter.blacklist` |
 | Seccomp mode/profile | not via `run` flag | `security.seccomp`, `security.customProfilePath` | `options.security.*` | `security.*` |
 | PID limit | `--pids-limit` | no default key | `options.pidsLimit` | `pidsLimit` |
-| Root FS writability | `--writable` flips readonly off | no default key | `options.readonlyRootFs` | `readonlyRootFs` |
+| Root FS writability | No `run` override | no default key | `options.readonlyRootFs` | `readonlyRootFs` |
 | Secrets masking source | `--secret KEY=VALUE` | no default key | `options.secrets` | `secrets` |
 
 <Info>

--- a/schema/isol8.config.schema.json
+++ b/schema/isol8.config.schema.json
@@ -140,6 +140,11 @@
               "default": "none",
               "description": "Default network mode."
             },
+            "readonlyRootFs": {
+              "default": true,
+              "description": "Whether the root filesystem should be read-only.",
+              "type": "boolean"
+            },
             "sandboxSize": {
               "default": "512m",
               "description": "Default size of the `/sandbox` tmpfs mount.",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -185,7 +185,6 @@ program
   .option("--cpu <limit>", "CPU limit as fraction (e.g. 0.5, 2.0)")
   .option("--image <name>", "Override Docker image")
   .option("--pids-limit <n>", "Maximum number of processes")
-  .option("--writable", "Disable read-only root filesystem")
   .option("--max-output <bytes>", "Maximum output size in bytes")
   .option("--secret <KEY=VALUE>", "Secret env var (repeatable, values masked)", collect, [])
   .option("--sandbox-size <size>", "Sandbox tmpfs size (e.g. 128m, 512m)")
@@ -1043,7 +1042,6 @@ async function resolveRunInput(file: string | undefined, opts: any) {
     timeoutMs: opts.timeout ? Number.parseInt(opts.timeout, 10) : config.defaults.timeoutMs,
     ...(opts.image ? { image: opts.image } : {}),
     ...(opts.pidsLimit ? { pidsLimit: Number.parseInt(opts.pidsLimit, 10) } : {}),
-    ...(opts.writable ? { readonlyRootFs: false } : {}),
     ...(opts.maxOutput ? { maxOutputSize: Number.parseInt(opts.maxOutput, 10) } : {}),
     ...(opts.tmpSize ? { tmpSize: opts.tmpSize } : {}),
     debug: opts.debug ?? config.debug,

--- a/src/config.ts
+++ b/src/config.ts
@@ -24,6 +24,7 @@ const DEFAULT_CONFIG: Isol8Config = {
     network: "none",
     sandboxSize: "512m",
     tmpSize: "256m",
+    readonlyRootFs: true,
   },
   network: {
     whitelist: [],
@@ -122,6 +123,7 @@ function mergeConfig(defaults: Isol8Config, overrides: Partial<Isol8Config>): Is
     defaults: {
       ...defaults.defaults,
       ...overrides.defaults,
+      readonlyRootFs: overrides.defaults?.readonlyRootFs ?? defaults.defaults.readonlyRootFs,
     },
     network: {
       whitelist: overrides.network?.whitelist ?? defaults.network.whitelist,

--- a/src/types.ts
+++ b/src/types.ts
@@ -458,6 +458,8 @@ export interface Isol8Defaults {
   sandboxSize: string;
   /** Default size of the `/tmp` tmpfs mount. @default "256m" */
   tmpSize: string;
+  /** Whether the root filesystem should be read-only. @default true */
+  readonlyRootFs: boolean;
 }
 
 /** Configuration for container cleanup and lifecycle. */

--- a/tests/integration/cli.test.ts
+++ b/tests/integration/cli.test.ts
@@ -28,7 +28,7 @@ describe("Integration: CLI", () => {
   test("installs packages via --install", async () => {
     // This might be slow
     const { stdout } = await runCLI(
-      'run -e "import numpy; print(numpy.__version__)" --runtime python --install numpy --net host --writable'
+      'run -e "import numpy; print(numpy.__version__)" --runtime python --install numpy --net host'
     );
     expect(stdout).toMatch(/\d+\.\d+\.\d+/);
   }, 120_000);

--- a/tests/production/cli-run.test.ts
+++ b/tests/production/cli-run.test.ts
@@ -193,13 +193,6 @@ describe("CLI Run - Filesystem", () => {
     const { stdout } = await runIsol8('run -e "print(5)" -r python --tmp-size 128m --no-stream');
     expect(stdout).toContain("5");
   }, 30_000);
-
-  test("--writable allows writing to sandbox", async () => {
-    const { stdout } = await runIsol8(
-      "run -e \"import os; os.makedirs('/sandbox/test_dir', exist_ok=True); print('writable-ok')\" -r python --writable --no-stream"
-    );
-    expect(stdout).toContain("writable-ok");
-  }, 30_000);
 });
 
 describe("CLI Run - Execution Modes", () => {

--- a/tests/unit/build.test.ts
+++ b/tests/unit/build.test.ts
@@ -215,7 +215,6 @@ describe("CLI help and version", () => {
       "--cpu",
       "--image",
       "--pids-limit",
-      "--writable",
       "--max-output",
       "--secret",
       "--sandbox-size",
@@ -1328,15 +1327,6 @@ except:
 `;
     const { stdout } = await runCLI(`run -e '${code}' -r python --net none --no-stream`);
     expect(stdout).toContain("blocked");
-  }, 30_000);
-
-  // ── --writable ─────────────────────────────────────────────────
-
-  test("--writable allows writing to root filesystem", async () => {
-    const { stdout } = await runCLI(
-      "run -e \"import os; os.makedirs('/sandbox/test_dir', exist_ok=True); print('writable-ok')\" -r python --writable --no-stream"
-    );
-    expect(stdout).toContain("writable-ok");
   }, 30_000);
 
   // ── --pids-limit ───────────────────────────────────────────────


### PR DESCRIPTION
## Description

This PR enforces a completely read-only root filesystem via the CLI by removing the `--writable` flag, mitigating potential security escape vectors. For programmatic and advanced use cases, the `readonlyRootFs` control has been migrated to the `Isol8Defaults` schema, allowing configuration via `isol8.config.json` while maintaining a secure default.

Additionally, this PR explicitly documents the persistence model of the engine inside a new guide at `docs/guides/persistent-execution.mdx` and aligns the file system documentation with the newly restricted security posture.

Fixes # (issue)

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📝 Documentation update
- [ ] ♻️ Refactor (code improvement without functional change)

## Scope

- [x] CLI
- [ ] Server
- [x] Docker Engine
- [x] Library (SDK)
- [x] Documentation

## Human Verification Checklist

> **Required**: Please check the following to confirm manual verification.

- [x] I have **manually reviewed** every line of code in this PR.
- [x] I have **tested** these changes locally and confirmed they work as expected.
- [x] This code is NOT entirely generated by AI; I understand and vouch for its correctness.

## Quality Checklist

- [x] My code follows the style guidelines of this project (run `bun run lint`).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
