### PR TITLE
feat(cli): add first-class custom image build command

### DIFF
--- a/.agents/skills/isol8/SKILL.md
+++ b/.agents/skills/isol8/SKILL.md
@@ -17,6 +17,7 @@ Isol8 is a secure execution engine for running untrusted code inside Docker cont
 |:--------|:--------|:----------|
 | `isol8 run [file]` | Execute code in an isolated container | [CLI: run](https://bingo-ccc81346.mintlify.app/cli/run) |
 | `isol8 setup` | Build Docker images, optionally bake in packages | [CLI: setup](https://bingo-ccc81346.mintlify.app/cli/setup) |
+| `isol8 build --base <runtime> --install <pkg>` | Build a custom runtime image with pre-baked dependencies | [CLI: build](https://bingo-ccc81346.mintlify.app/cli/build) |
 | `isol8 cleanup` | Remove orphaned isol8 containers | [CLI: cleanup](https://bingo-ccc81346.mintlify.app/cli/cleanup) |
 | `isol8 serve` | Start HTTP server for remote execution (downloads binary on first use) | [CLI: serve](https://bingo-ccc81346.mintlify.app/cli/serve) |
 | `isol8 config` | Display resolved configuration | [CLI: config](https://bingo-ccc81346.mintlify.app/cli/config) |

--- a/README.md
+++ b/README.md
@@ -141,6 +141,25 @@ isol8 run script.py --host http://server:3000 --key my-api-key
 | `--host <url>` | Remote server URL | — |
 | `--key <key>` | API key for remote server | `$ISOL8_API_KEY` |
 
+### `isol8 build`
+
+Build a custom runtime image with pre-baked dependencies.
+
+```bash
+# Build a hashed custom Python image
+isol8 build --base python --install numpy --install pandas
+
+# Build and tag an alias for easier reuse
+isol8 build --base python --install numpy,pandas,torch --tag my-registry/ml-image:latest
+```
+
+| Flag | Description |
+|------|-------------|
+| `--base <runtime>` | Runtime base image: `python`, `node`, `bun`, `deno`, `bash` |
+| `--install <pkg>` | Package to install (repeatable or comma-separated) |
+| `--tag <name>` | Optional alias tag for the built image |
+| `--force` | Force rebuild even when image is up to date |
+
 ### Remote Code URLs
 
 ```bash

--- a/apps/cli/tests/build.test.ts
+++ b/apps/cli/tests/build.test.ts
@@ -169,6 +169,7 @@ describe("CLI help and version", () => {
     expect(stdout).toContain("isol8");
     expect(stdout).toContain("setup");
     expect(stdout).toContain("run");
+    expect(stdout).toContain("build");
     expect(stdout).toContain("serve");
     expect(stdout).toContain("config");
     expect(stdout).toContain("cleanup");
@@ -227,6 +228,13 @@ describe("CLI help and version", () => {
   test("setup --help lists setup flags", async () => {
     const { stdout } = await runCLI("setup --help");
     for (const flag of ["--python", "--node", "--bun", "--deno", "--bash"]) {
+      expect(stdout).toContain(flag);
+    }
+  });
+
+  test("build --help lists build flags", async () => {
+    const { stdout } = await runCLI("build --help");
+    for (const flag of ["--base", "--install", "--tag", "--force"]) {
       expect(stdout).toContain(flag);
     }
   });

--- a/apps/docs/cli.mdx
+++ b/apps/docs/cli.mdx
@@ -1,7 +1,7 @@
 ---
 title: "How to CLI"
 sidebarTitle: "How to CLI"
-description: "Detailed command-line guide for isol8 with flag-by-flag behavior for run, setup, serve, config, and cleanup commands."
+description: "Detailed command-line guide for isol8 with flag-by-flag behavior for run, setup, build, serve, config, and cleanup commands."
 icon: "terminal"
 ---
 
@@ -232,6 +232,28 @@ isol8 serve --key <api-key> [options]
 <Info>
   For full server behavior and endpoints, see the Server docs tab: <a href="/server/overview">Server overview</a> and <a href="/server/routes">Server routes</a>.
 </Info>
+
+## `isol8 build`
+
+```bash
+isol8 build --base <runtime> --install <package> [options]
+```
+
+<ResponseField name="--base <runtime>" type="python | node | bun | deno | bash">
+  Runtime base image to extend.
+</ResponseField>
+
+<ResponseField name="--install <package>" type="repeatable">
+  Package to bake into the image. Supports repeated flags and comma-separated values.
+</ResponseField>
+
+<ResponseField name="--tag <name>" type="string">
+  Optional alias tag (for example `my-registry/ml-image:latest`) applied to the built hashed image.
+</ResponseField>
+
+<ResponseField name="--force" type="flag">
+  Force rebuild even if current inputs resolve to an existing up-to-date image.
+</ResponseField>
 
 ## `isol8 config`
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -16,7 +16,12 @@ export { Semaphore } from "./engine/concurrency";
 export type { DockerIsol8Options } from "./engine/docker";
 // ─── Engine ───
 export { DockerIsol8 } from "./engine/docker";
-export { buildBaseImages, buildCustomImages } from "./engine/image-builder";
+export {
+  buildBaseImages,
+  buildCustomImage,
+  buildCustomImages,
+  getCustomImageTag,
+} from "./engine/image-builder";
 // ─── Runtime ───
 export {
   BunAdapter,


### PR DESCRIPTION
## Description

Adds a first-class custom image build workflow to the CLI via a new `isol8 build` command.

What this change delivers:
- new `isol8 build` command to build runtime-specific custom images with pre-baked dependencies
- supports repeatable and comma-separated package input (`--install`)
- optional alias tagging (`--tag`) for user-friendly image names
- force rebuild support (`--force`)
- docs updates in root README, CLI docs, and skill quick-reference

This addresses the primary DX gap in issue #35 by making custom image creation explicit and discoverable from the CLI.

Fixes #35

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📝 Documentation update
- [ ] ♻️ Refactor (code improvement without functional change)

## Scope

- [x] CLI
- [ ] Server
- [ ] Docker Engine
- [x] Library (SDK)
- [x] Documentation

## Human Verification Checklist

> **Required**: Please check the following to confirm manual verification.

- [x] I have **manually reviewed** every line of code in this PR.
- [x] I have **tested** these changes locally and confirmed they work as expected.
- [x] This code is NOT entirely generated by AI; I understand and vouch for its correctness.

## Quality Checklist

- [x] My code follows the style guidelines of this project (run `bun run lint`).
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## Implementation Notes

### New CLI command
`isol8 build --base <runtime> --install <pkg> [--install <pkg2>] [--tag <image:tag>] [--force]`

- validates runtime input (`python`, `node`, `bun`, `deno`, `bash`)
- ensures base runtime image exists before custom layering
- builds deterministic hashed custom image via core image builder
- can apply alias tag to the built image for easier reuse

### Validation run
- `bunx tsc --noEmit`
- `bun run lint:check`
- `bun run --filter @isol8/core build`
- `bun run --filter @isol8/cli build`
- `node apps/cli/dist/cli.js build --help`

### Testing gap note
`bun test apps/cli/tests/build.test.ts` currently fails in this repo due an existing test path issue resolving `apps/apps/...` dist paths (pre-existing, not introduced by this PR).
