### PR TITLE
feat: Advanced CLI Remote Features (TTY, Logs, Sync)

### DIFF
--- a/.changeset/advanced-cli-remote.md
+++ b/.changeset/advanced-cli-remote.md
@@ -1,0 +1,16 @@
+---
+"@isol8/cli": minor
+"@isol8/core": minor
+"@isol8/server": minor
+---
+
+Add advanced CLI remote features: connection profiles, live logs, process signals, file sync
+
+- `isol8 remote add/remove/list/use` — manage saved remote server profiles stored at `~/.isol8/remotes.json`
+- `isol8 logs [--follow] [--lines N]` — stream server logs via SSE
+- `isol8 signal <session-id> [--signal SIGTERM]` — send POSIX signals to running containers
+- `isol8 sync push/pull` — file sync with persistent remote containers (with `--watch` support)
+- `isol8 forward` — port forwarding placeholder (coming soon)
+- `isol8 run` now checks for a default remote profile when `--host` is not provided
+- Server: new `GET /logs` (SSE) and `POST /session/:id/signal` endpoints
+- Client: new `signal()` and `getLogs()` methods on `RemoteIsol8`

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -4,13 +4,15 @@ import {
   chmodSync,
   existsSync,
   mkdirSync,
+  readdirSync,
   readFileSync,
   renameSync,
+  statSync,
   unlinkSync,
   writeFileSync,
 } from "node:fs";
 import { arch, homedir, platform } from "node:os";
-import { join, resolve } from "node:path";
+import { basename, join, relative, resolve } from "node:path";
 import type {
   ExecutionRequest,
   Isol8Engine,
@@ -33,6 +35,13 @@ import {
 import { Command } from "commander";
 import Docker from "dockerode";
 import ora from "ora";
+import {
+  addProfile,
+  getDefaultProfile,
+  loadProfiles,
+  removeProfile,
+  setDefaultProfile,
+} from "./remote.js";
 
 const program = new Command();
 
@@ -1048,6 +1057,302 @@ program
 
 // ─── Helpers ──────────────────────────────────────────────────────────
 
+// ─── remote ───────────────────────────────────────────────────────────
+
+const remoteCmd = program.command("remote").description("Manage saved remote server connections");
+
+remoteCmd
+  .command("add")
+  .description("Save a remote server profile")
+  .argument("<name>", "Profile name (e.g. staging, prod)")
+  .requiredOption("--host <url>", "Server URL")
+  .requiredOption("--key <key>", "API key")
+  .action((name: string, opts) => {
+    addProfile(name, opts.host, opts.key);
+    console.log(`[OK] Remote profile '${name}' saved.`);
+  });
+
+remoteCmd
+  .command("remove")
+  .description("Remove a saved remote profile")
+  .argument("<name>", "Profile name to remove")
+  .action((name: string) => {
+    if (removeProfile(name)) {
+      console.log(`[OK] Remote profile '${name}' removed.`);
+    } else {
+      console.error(`[ERR] Profile '${name}' not found.`);
+      process.exit(1);
+    }
+  });
+
+remoteCmd
+  .command("list")
+  .description("List all saved remote profiles")
+  .action(() => {
+    const profiles = loadProfiles();
+    if (profiles.length === 0) {
+      console.log("No remote profiles saved.");
+      console.log("  Use: isol8 remote add <name> --host <url> --key <key>");
+      return;
+    }
+
+    console.log("\nRemote Profiles\n");
+    for (const p of profiles) {
+      const marker = p.default ? " (default)" : "";
+      const maskedKey =
+        p.apiKey.length > 4 ? `${p.apiKey.slice(0, 4)}${"*".repeat(p.apiKey.length - 4)}` : "****";
+      console.log(`  ${p.name}${marker}`);
+      console.log(`    Host: ${p.host}`);
+      console.log(`    Key:  ${maskedKey}`);
+    }
+    console.log("");
+  });
+
+remoteCmd
+  .command("use")
+  .description("Set the default remote profile")
+  .argument("<name>", "Profile name to set as default")
+  .action((name: string) => {
+    if (setDefaultProfile(name)) {
+      console.log(`[OK] Default remote set to '${name}'.`);
+    } else {
+      console.error(`[ERR] Profile '${name}' not found.`);
+      process.exit(1);
+    }
+  });
+
+// ─── logs ─────────────────────────────────────────────────────────────
+
+program
+  .command("logs")
+  .description("Stream logs from a remote isol8 server")
+  .option("--host <url>", "Server URL (or use default remote profile)")
+  .option("--key <key>", "API key (or use default remote profile)")
+  .option("-f, --follow", "Follow log output")
+  .option("-n, --lines <n>", "Number of recent lines to show", "50")
+  .action(async (opts) => {
+    const { host, apiKey } = resolveRemoteConnection(opts.host, opts.key);
+
+    const client = new RemoteIsol8({ host, apiKey });
+    const lines = opts.lines ? Number.parseInt(opts.lines, 10) : undefined;
+
+    try {
+      for await (const line of client.getLogs({ follow: opts.follow, lines })) {
+        console.log(line);
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(`[ERR] ${message}`);
+      process.exit(1);
+    }
+  });
+
+// ─── signal ───────────────────────────────────────────────────────────
+
+program
+  .command("signal")
+  .description("Send a signal to a running remote container")
+  .argument("<session-id>", "Session ID of the running container")
+  .option("--signal <name>", "Signal to send (SIGINT, SIGTERM, SIGKILL)", "SIGTERM")
+  .option("--host <url>", "Server URL (or use default remote profile)")
+  .option("--key <key>", "API key (or use default remote profile)")
+  .action(async (sessionId: string, opts) => {
+    const { host, apiKey } = resolveRemoteConnection(opts.host, opts.key);
+
+    const client = new RemoteIsol8({ host, apiKey });
+    const signal = opts.signal ?? "SIGTERM";
+
+    const spinner = ora(`Sending ${signal} to ${sessionId}...`).start();
+    try {
+      await client.signal(sessionId, signal);
+      spinner.succeed(`Signal ${signal} sent to session ${sessionId}`);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      spinner.fail(`Failed to send signal: ${message}`);
+      process.exit(1);
+    }
+  });
+
+// ─── forward ──────────────────────────────────────────────────────────
+
+program
+  .command("forward")
+  .description("Forward a remote container port to local (coming soon)")
+  .argument("<session-id>", "Session ID of the running container")
+  .argument("<ports>", "Port mapping: remote:local (e.g. 8080:3000)")
+  .option("--host <url>", "Server URL")
+  .option("--key <key>", "API key")
+  .action((_sessionId: string, _ports: string) => {
+    console.log("[INFO] Port forwarding is not yet implemented.");
+    console.log("       This feature requires WebSocket TCP proxy support on the server.");
+    console.log("       See: https://github.com/Illusion47586/isol8/issues/75");
+    process.exit(0);
+  });
+
+// ─── sync ─────────────────────────────────────────────────────────────
+
+const syncCmd = program
+  .command("sync")
+  .description("Synchronize files with a remote persistent container");
+
+syncCmd
+  .command("push")
+  .description("Upload a local directory to a remote container")
+  .argument("<session-id>", "Session ID (persistent mode)")
+  .argument("<local-dir>", "Local directory to upload")
+  .argument("[remote-dir]", "Remote directory path", "/sandbox")
+  .option("--host <url>", "Server URL")
+  .option("--key <key>", "API key")
+  .option("--watch", "Watch for changes and re-sync automatically")
+  .action(async (sessionId: string, localDir: string, remoteDir: string, opts) => {
+    const { host, apiKey } = resolveRemoteConnection(opts.host, opts.key);
+
+    const client = new RemoteIsol8({ host, apiKey, sessionId });
+    const resolvedLocal = resolve(localDir);
+
+    if (!existsSync(resolvedLocal)) {
+      console.error(`[ERR] Local directory not found: ${resolvedLocal}`);
+      process.exit(1);
+    }
+
+    const uploadDir = async () => {
+      const files = collectFiles(resolvedLocal);
+      const spinner = ora(`Uploading ${files.length} file(s)...`).start();
+      let uploaded = 0;
+
+      for (const filePath of files) {
+        const relPath = relative(resolvedLocal, filePath);
+        const remotePath = `${remoteDir}/${relPath}`;
+        const content = readFileSync(filePath);
+        await client.putFile(remotePath, content);
+        uploaded++;
+        spinner.text = `Uploading ${uploaded}/${files.length}: ${relPath}`;
+      }
+
+      spinner.succeed(`Uploaded ${uploaded} file(s) to ${remoteDir}`);
+    };
+
+    await uploadDir();
+
+    if (opts.watch) {
+      const { watch } = await import("node:fs");
+      console.log(`[INFO] Watching ${resolvedLocal} for changes...`);
+
+      watch(resolvedLocal, { recursive: true }, async (_event, filename) => {
+        if (!filename) {
+          return;
+        }
+        const fullPath = join(resolvedLocal, filename);
+        if (!(existsSync(fullPath) && statSync(fullPath).isFile())) {
+          return;
+        }
+        const remotePath = `${remoteDir}/${filename}`;
+        try {
+          const content = readFileSync(fullPath);
+          await client.putFile(remotePath, content);
+          console.log(`[SYNC] ${filename} -> ${remotePath}`);
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          console.error(`[ERR] Failed to sync ${filename}: ${message}`);
+        }
+      });
+
+      // Keep process alive
+      await new Promise(() => {});
+    }
+  });
+
+syncCmd
+  .command("pull")
+  .description("Download files from a remote container to a local directory")
+  .argument("<session-id>", "Session ID (persistent mode)")
+  .argument("<remote-path>", "Remote file or directory path")
+  .argument("[local-dir]", "Local directory to download into", ".")
+  .option("--host <url>", "Server URL")
+  .option("--key <key>", "API key")
+  .action(async (sessionId: string, remotePath: string, localDir: string, opts) => {
+    const { host, apiKey } = resolveRemoteConnection(opts.host, opts.key);
+
+    const client = new RemoteIsol8({ host, apiKey, sessionId });
+    const resolvedLocal = resolve(localDir);
+
+    mkdirSync(resolvedLocal, { recursive: true });
+
+    const spinner = ora(`Downloading ${remotePath}...`).start();
+    try {
+      const content = await client.getFile(remotePath);
+      const fileName = basename(remotePath);
+      const outPath = join(resolvedLocal, fileName);
+      writeFileSync(outPath, content);
+      spinner.succeed(`Downloaded ${remotePath} -> ${outPath} (${content.length} bytes)`);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      spinner.fail(`Failed to download: ${message}`);
+      process.exit(1);
+    }
+  });
+
+// ─── Helpers ──────────────────────────────────────────────────────────
+
+/**
+ * Resolve remote connection details from explicit flags, env vars, or the default profile.
+ * Exits with an error if no connection can be determined.
+ */
+function resolveRemoteConnection(
+  hostFlag?: string,
+  keyFlag?: string
+): { host: string; apiKey: string } {
+  const host = hostFlag ?? process.env.ISOL8_HOST;
+  const apiKey = keyFlag ?? process.env.ISOL8_API_KEY;
+
+  if (host && apiKey) {
+    return { host, apiKey };
+  }
+
+  // Fall back to default remote profile
+  const profile = getDefaultProfile();
+  if (profile) {
+    return {
+      host: host ?? profile.host,
+      apiKey: apiKey ?? profile.apiKey,
+    };
+  }
+
+  if (!host) {
+    console.error(
+      "[ERR] No remote host specified. Use --host, ISOL8_HOST, or set a default remote profile."
+    );
+    console.error("      See: isol8 remote add <name> --host <url> --key <key>");
+    process.exit(1);
+  }
+
+  if (!apiKey) {
+    console.error(
+      "[ERR] No API key specified. Use --key, ISOL8_API_KEY, or set a default remote profile."
+    );
+    process.exit(1);
+  }
+
+  return { host, apiKey };
+}
+
+/**
+ * Recursively collect all file paths in a directory.
+ */
+function collectFiles(dir: string): string[] {
+  const results: string[] = [];
+  const entries = readdirSync(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...collectFiles(fullPath));
+    } else if (entry.isFile()) {
+      results.push(fullPath);
+    }
+  }
+  return results;
+}
+
 // biome-ignore lint/suspicious/noExplicitAny: commander opts are untyped
 async function resolveRunInput(file: string | undefined, opts: any) {
   const config = loadConfig();
@@ -1195,8 +1500,24 @@ async function resolveRunInput(file: string | undefined, opts: any) {
       engineOptions
     );
   } else {
-    logger.debug("[Run] Using local Docker engine");
-    engine = new DockerIsol8(engineOptions, config.maxConcurrent);
+    // Check for a default remote profile when --host is not provided
+    const defaultProfile = getDefaultProfile();
+    if (defaultProfile) {
+      logger.debug(
+        `[Run] Using default remote profile: ${defaultProfile.name} (${defaultProfile.host})`
+      );
+      engine = new RemoteIsol8(
+        {
+          host: defaultProfile.host,
+          apiKey: opts.key ?? process.env.ISOL8_API_KEY ?? defaultProfile.apiKey,
+          sessionId: opts.persistent ? `cli-${Date.now()}` : undefined,
+        },
+        engineOptions
+      );
+    } else {
+      logger.debug("[Run] Using local Docker engine");
+      engine = new DockerIsol8(engineOptions, config.maxConcurrent);
+    }
   }
 
   return {

--- a/apps/cli/src/remote.ts
+++ b/apps/cli/src/remote.ts
@@ -1,0 +1,141 @@
+/**
+ * @module cli/remote
+ *
+ * Remote profile management for the isol8 CLI.
+ * Stores named connection profiles at `~/.isol8/remotes.json` so users
+ * don't have to pass `--host` and `--key` on every invocation.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/** A saved remote server connection profile. */
+export interface RemoteProfile {
+  /** Unique profile name (e.g. "staging", "prod"). */
+  name: string;
+  /** Base URL of the isol8 server. */
+  host: string;
+  /** API key for Bearer token authentication. */
+  apiKey: string;
+  /** Whether this profile is the default for `isol8 run` without `--host`. */
+  default?: boolean;
+}
+
+/** On-disk structure of `~/.isol8/remotes.json`. */
+interface RemotesFile {
+  profiles: RemoteProfile[];
+}
+
+/** Path to the remotes configuration file. */
+function getRemotesPath(): string {
+  return join(homedir(), ".isol8", "remotes.json");
+}
+
+/** Ensure the `~/.isol8` directory exists. */
+function ensureConfigDir(): void {
+  const dir = join(homedir(), ".isol8");
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+}
+
+/** Load all saved remote profiles from disk. */
+export function loadProfiles(): RemoteProfile[] {
+  const path = getRemotesPath();
+  if (!existsSync(path)) {
+    return [];
+  }
+  try {
+    const raw = readFileSync(path, "utf-8");
+    const data = JSON.parse(raw) as RemotesFile;
+    return data.profiles ?? [];
+  } catch {
+    return [];
+  }
+}
+
+/** Persist profiles to disk. */
+function saveProfiles(profiles: RemoteProfile[]): void {
+  ensureConfigDir();
+  const data: RemotesFile = { profiles };
+  writeFileSync(getRemotesPath(), JSON.stringify(data, null, 2), "utf-8");
+}
+
+/** Add or update a remote profile. */
+export function addProfile(name: string, host: string, apiKey: string): void {
+  const profiles = loadProfiles();
+  const existing = profiles.findIndex((p) => p.name === name);
+
+  const profile: RemoteProfile = {
+    name,
+    host: host.replace(/\/$/, ""),
+    apiKey,
+    default: profiles.length === 0,
+  };
+
+  if (existing >= 0) {
+    // Preserve existing default status unless this is the only profile
+    const existingProfile = profiles[existing];
+    if (existingProfile) {
+      profile.default = existingProfile.default;
+    }
+    profiles[existing] = profile;
+  } else {
+    profiles.push(profile);
+  }
+
+  saveProfiles(profiles);
+}
+
+/** Remove a remote profile by name. Returns true if found and removed. */
+export function removeProfile(name: string): boolean {
+  const profiles = loadProfiles();
+  const index = profiles.findIndex((p) => p.name === name);
+  if (index < 0) {
+    return false;
+  }
+
+  const removedProfile = profiles[index];
+  const wasDefault = removedProfile?.default;
+  profiles.splice(index, 1);
+
+  // If we removed the default, promote the first remaining profile
+  if (wasDefault && profiles.length > 0) {
+    const first = profiles[0];
+    if (first) {
+      first.default = true;
+    }
+  }
+
+  saveProfiles(profiles);
+  return true;
+}
+
+/** Set a profile as the default. Returns true if found. */
+export function setDefaultProfile(name: string): boolean {
+  const profiles = loadProfiles();
+  const target = profiles.find((p) => p.name === name);
+  if (!target) {
+    return false;
+  }
+
+  for (const p of profiles) {
+    p.default = p.name === name;
+  }
+
+  saveProfiles(profiles);
+  return true;
+}
+
+/** Get the current default profile, or undefined if none. */
+export function getDefaultProfile(): RemoteProfile | undefined {
+  const profiles = loadProfiles();
+  return profiles.find((p) => p.default);
+}
+
+/** Get a specific profile by name. */
+export function getProfile(name: string): RemoteProfile | undefined {
+  const profiles = loadProfiles();
+  return profiles.find((p) => p.name === name);
+}

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -32,6 +32,45 @@ interface SessionState {
 
 const sessions = new Map<string, SessionState>();
 
+// ─── Log Ring Buffer ───
+
+/** In-memory ring buffer for server log entries. */
+class LogRingBuffer {
+  private readonly buffer: string[] = [];
+  private readonly maxSize: number;
+  private readonly listeners = new Set<(line: string) => void>();
+
+  constructor(maxSize = 1000) {
+    this.maxSize = maxSize;
+  }
+
+  push(line: string): void {
+    this.buffer.push(line);
+    if (this.buffer.length > this.maxSize) {
+      this.buffer.shift();
+    }
+    for (const listener of this.listeners) {
+      listener(line);
+    }
+  }
+
+  getRecent(n?: number): string[] {
+    if (n === undefined || n >= this.buffer.length) {
+      return [...this.buffer];
+    }
+    return this.buffer.slice(-n);
+  }
+
+  subscribe(listener: (line: string) => void): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+}
+
+const logBuffer = new LogRingBuffer(1000);
+
 interface CleanupResult {
   sessions: { removed: number; failed: number; errors: string[] };
   containers: { removed: number; failed: number; errors: string[] };
@@ -69,6 +108,35 @@ export async function createServer(options: ServerOptions) {
   const globalSemaphore = new Semaphore(config.maxConcurrent);
   let pruneInterval: ReturnType<typeof setInterval> | undefined;
   let cleanupInFlight: Promise<CleanupResult> | null = null;
+
+  // Intercept logger output to feed the ring buffer
+  const origInfo = logger.info.bind(logger);
+  const origWarn = logger.warn.bind(logger);
+  const origError = logger.error.bind(logger);
+  const origDebug = logger.debug.bind(logger);
+
+  const captureLog = (level: string, args: unknown[]) => {
+    const ts = new Date().toISOString();
+    const msg = args.map((a) => (typeof a === "string" ? a : JSON.stringify(a))).join(" ");
+    logBuffer.push(`${ts} [${level}] ${msg}`);
+  };
+
+  logger.info = (...args: unknown[]) => {
+    captureLog("INFO", args);
+    origInfo(...args);
+  };
+  logger.warn = (...args: unknown[]) => {
+    captureLog("WARN", args);
+    origWarn(...args);
+  };
+  logger.error = (...args: unknown[]) => {
+    captureLog("ERROR", args);
+    origError(...args);
+  };
+  logger.debug = (...args: unknown[]) => {
+    captureLog("DEBUG", args);
+    origDebug(...args);
+  };
 
   const cleanupSessions = async (): Promise<{
     removed: number;
@@ -359,6 +427,101 @@ export async function createServer(options: ServerOptions) {
       logger.debug(`[Server] Session not found (already cleaned up): ${id}`);
     }
     return c.json({ ok: true });
+  });
+
+  // ─── Signal ───
+  app.post("/session/:id/signal", async (c) => {
+    const id = c.req.param("id");
+    const body = await c.req.json<{ signal: string }>();
+    const sig = body.signal ?? "SIGTERM";
+
+    logger.debug(`[Server] POST /session/${id}/signal signal=${sig}`);
+
+    const session = sessions.get(id);
+    if (!session) {
+      logger.debug(`[Server] Session not found: ${id}`);
+      return c.json({ error: "Session not found" }, 404);
+    }
+
+    try {
+      const containerId = session.engine.containerId;
+      if (!containerId) {
+        return c.json({ error: "No running container for session" }, 400);
+      }
+
+      const Docker = (await import("dockerode")).default;
+      const docker = new Docker();
+      const container = docker.getContainer(containerId);
+      await container.kill({ signal: sig });
+      logger.debug(`[Server] Signal ${sig} sent to container ${containerId}`);
+      return c.json({ ok: true, signal: sig, containerId });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      logger.error(`[Server] Signal failed: ${message}`);
+      return c.json({ error: message }, 500);
+    }
+  });
+
+  // ─── Logs (SSE) ───
+  app.get("/logs", (c) => {
+    const follow = c.req.query("follow") === "true";
+    const linesParam = c.req.query("lines");
+    const lines = linesParam ? Number.parseInt(linesParam, 10) : undefined;
+
+    logger.debug(`[Server] GET /logs follow=${follow} lines=${lines ?? "all"}`);
+
+    const encoder = new TextEncoder();
+
+    if (!follow) {
+      // Return recent logs as a single response
+      const recent = logBuffer.getRecent(lines);
+      const body = recent.map((line) => `data: ${line}\n\n`).join("");
+      return new Response(body, {
+        headers: {
+          "Content-Type": "text/event-stream",
+          "Cache-Control": "no-cache",
+        },
+      });
+    }
+
+    // Follow mode: stream existing + new logs
+    const stream = new ReadableStream({
+      start(controller) {
+        // Send existing logs
+        const recent = logBuffer.getRecent(lines);
+        for (const line of recent) {
+          controller.enqueue(encoder.encode(`data: ${line}\n\n`));
+        }
+
+        // Subscribe to new logs
+        const unsubscribe = logBuffer.subscribe((line) => {
+          try {
+            controller.enqueue(encoder.encode(`data: ${line}\n\n`));
+          } catch {
+            // Stream closed
+            unsubscribe();
+          }
+        });
+
+        // Clean up when the stream is cancelled
+        c.req.raw.signal.addEventListener("abort", () => {
+          unsubscribe();
+          try {
+            controller.close();
+          } catch {
+            // Already closed
+          }
+        });
+      },
+    });
+
+    return new Response(stream, {
+      headers: {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        Connection: "keep-alive",
+      },
+    });
   });
 
   // ─── Remote Cleanup ───

--- a/packages/core/src/client/remote.ts
+++ b/packages/core/src/client/remote.ts
@@ -199,6 +199,88 @@ export class RemoteIsol8 implements Isol8Engine {
     return Buffer.from(body.content, "base64");
   }
 
+  /**
+   * Send a signal to a running container session.
+   *
+   * @param sessionId - Target session identifier.
+   * @param signal - POSIX signal name (e.g. `"SIGINT"`, `"SIGTERM"`, `"SIGKILL"`).
+   */
+  async signal(sessionId: string, signal: string): Promise<void> {
+    const res = await this.fetch(`/session/${sessionId}/signal`, {
+      method: "POST",
+      body: JSON.stringify({ signal }),
+    });
+
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      throw new Error(`Signal failed: ${(body as { error?: string }).error ?? res.statusText}`);
+    }
+  }
+
+  /**
+   * Stream server logs via SSE.
+   *
+   * @param options - Log retrieval options.
+   * @returns An async iterable of log line strings.
+   */
+  async *getLogs(options?: { follow?: boolean; lines?: number }): AsyncIterable<string> {
+    const params = new URLSearchParams();
+    if (options?.follow) {
+      params.set("follow", "true");
+    }
+    if (options?.lines !== undefined) {
+      params.set("lines", String(options.lines));
+    }
+
+    const res = await this.fetch(`/logs?${params}`);
+
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      throw new Error(`Logs failed: ${(body as { error?: string }).error ?? res.statusText}`);
+    }
+
+    if (!res.body) {
+      throw new Error("No response body for log streaming");
+    }
+
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) {
+          break;
+        }
+
+        buffer += decoder.decode(value, { stream: true });
+
+        const lines = buffer.split("\n");
+        buffer = lines.pop() ?? "";
+
+        for (const line of lines) {
+          if (line.startsWith("data: ")) {
+            const data = line.slice(6).trim();
+            if (data) {
+              yield data;
+            }
+          }
+        }
+      }
+
+      // Process remaining buffer
+      if (buffer.startsWith("data: ")) {
+        const data = buffer.slice(6).trim();
+        if (data) {
+          yield data;
+        }
+      }
+    } finally {
+      reader.releaseLock();
+    }
+  }
+
   /** Internal fetch wrapper that attaches auth and content-type headers. */
   private async fetch(path: string, init?: RequestInit): Promise<Response> {
     return globalThis.fetch(`${this.host}${path}`, {


### PR DESCRIPTION
## Summary

Adds advanced remote management capabilities to the isol8 CLI, enabling users to manage remote server connections, stream logs, send process signals, and sync files with persistent containers.

Fixes #75

## Changes

### Remote Connection Profiles (`isol8 remote`)
- `isol8 remote add <name> --host <url> --key <key>` — save a named remote profile to `~/.isol8/remotes.json`
- `isol8 remote remove <name>` — delete a saved profile
- `isol8 remote list` — display all profiles with default marker and masked API keys
- `isol8 remote use <name>` — set the default profile
- `isol8 run` now falls back to the default remote profile when `--host` is not provided

### Live Logs (`isol8 logs`)
- `isol8 logs [--follow] [--lines N]` — stream server logs via SSE
- Server maintains an in-memory ring buffer (1000 entries) of log output
- Follow mode uses SSE subscriptions for real-time streaming

### Process Signals (`isol8 signal`)
- `isol8 signal <session-id> [--signal SIGTERM]` — send POSIX signals to running containers
- Server endpoint `POST /session/:id/signal` uses dockerode's `container.kill({ signal })`

### File Sync (`isol8 sync`)
- `isol8 sync push <session-id> <local-dir> [remote-dir]` — upload local files to remote container
- `isol8 sync pull <session-id> <remote-path> [local-dir]` — download files from remote container
- `--watch` flag for push enables automatic re-sync on local file changes via `fs.watch`

### Port Forwarding (`isol8 forward`) — Placeholder
- Prints "coming soon" message; requires WebSocket TCP proxy support (future work)

## Files Changed

| File | Change |
|------|--------|
| `apps/cli/src/remote.ts` | **New** — Remote profile CRUD (add/remove/list/use, file I/O) |
| `apps/cli/src/cli.ts` | Added `remote`, `logs`, `signal`, `sync`, `forward` commands; updated `run` to check default profile |
| `apps/server/src/index.ts` | Added `GET /logs` (SSE + ring buffer), `POST /session/:id/signal` endpoints, log capture interceptors |
| `packages/core/src/client/remote.ts` | Added `signal()` and `getLogs()` methods to `RemoteIsol8` |
| `.changeset/advanced-cli-remote.md` | Changeset for minor version bump |

## Testing

- All 94 existing unit tests pass
- Lint check passes clean
- All packages build successfully