### PR TITLE
feat: add agent runtime for AI coding agent (pi) sandbox execution

### DIFF
--- a/.agents/skills/isol8/SKILL.md
+++ b/.agents/skills/isol8/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: isol8
-description: Securely execute untrusted Python, Node.js, Bun, Deno, and Bash code in sandboxed Docker containers.
+description: Securely execute untrusted Python, Node.js, Bun, Deno, Bash, and AI agent code in sandboxed Docker containers.
 ---
 
 # Isol8 Skill
 
-Isol8 is a secure execution engine for running untrusted code inside Docker containers with strict resource limits, network controls, and output sanitization. Use this skill when you need to execute code, scripts, or system commands in a safe, isolated environment.
+Isol8 is a secure execution engine for running untrusted code inside Docker containers with strict resource limits, network controls, and output sanitization. Use this skill when you need to execute code, scripts, system commands, or AI coding agents in a safe, isolated environment.
 
 > For full documentation, see the [isol8 docs](https://bingo-ccc81346.mintlify.app). This file is a quick-reference for AI agents — it covers the most common operations and links to detailed docs for everything else.
 
@@ -28,14 +28,14 @@ Isol8 is a secure execution engine for running untrusted code inside Docker cont
 2. File argument (runtime auto-detected from extension, or forced with `--runtime`)
 3. Stdin (defaults to `python` runtime)
 
-**Extension mapping:** `.py` → python, `.js`/`.mjs`/`.cjs` → node, `.ts` → bun, `.mts` → deno, `.sh` → bash
+**Extension mapping:** `.py` → python, `.js`/`.mjs`/`.cjs` → node, `.ts` → bun, `.mts` → deno, `.sh` → bash. The `agent` runtime has no file extension mapping and must be specified explicitly with `--runtime agent`.
 
 ### Most-Used Flags (`isol8 run`)
 
 | Flag | Default | Description |
 |:-----|:--------|:------------|
 | `-e, --eval <code>` | — | Execute inline code |
-| `-r, --runtime <name>` | auto-detect | Force: `python`, `node`, `bun`, `deno`, `bash` |
+| `-r, --runtime <name>` | auto-detect | Force: `python`, `node`, `bun`, `deno`, `bash`, `agent` |
 | `--no-stream` | `false` | Disable real-time output streaming |
 | `--persistent` | `false` | Keep container alive between runs |
 | `--persist` | `false` | Keep container after execution for debugging |
@@ -71,6 +71,12 @@ isol8 run -e "import os; print(os.environ['KEY'])" --runtime python --secret KEY
 
 # Remote execution
 isol8 run script.py --host http://server:3000 --key my-api-key
+
+# AI coding agent (sandboxed)
+isol8 run -e "refactor this to use async/await" --runtime agent \
+  --net filtered --allow "api.anthropic.com" \
+  --secret "ANTHROPIC_API_KEY=sk-..." \
+  --files ./my-project --workdir /sandbox/my-project --timeout 600000
 
 # Cleanup orphaned containers
 isol8 cleanup               # Interactive (prompts for confirmation)
@@ -199,3 +205,6 @@ Full security model: [Security](https://bingo-ccc81346.mintlify.app/security)
 - **"Operation not permitted" with numpy/packages**: Packages need `--sandbox-size` large enough for installation (512MB+ recommended).
 - **`.ts` files running with Bun instead of Deno**: `.ts` defaults to Bun. Use `--runtime deno` or `.mts` extension.
 - **Serve command failing**: Ensure the server binary can be downloaded from GitHub Releases. Use `isol8 serve --update` to force a fresh download. Use `isol8 serve --debug` to see detailed server logs. For listen port selection, precedence is `--port` > `ISOL8_PORT` > `PORT` > `3000`; if the port is busy, `serve` can prompt for another port or auto-pick an available one.
+- **Agent runtime requires filtered network**: The `agent` runtime enforces `--net filtered` with at least one `--allow` entry. Pass `--allow "api.anthropic.com"` (or your LLM provider's domain).
+- **Agent runtime needs API key**: Pass the LLM provider key via `--secret "ANTHROPIC_API_KEY=sk-..."`. The value is masked in output.
+- **Agent runtime out of space**: The agent runtime defaults to `--sandbox-size 2g`. For large repos, increase with `--sandbox-size 4g`.

--- a/.changeset/add-agent-runtime.md
+++ b/.changeset/add-agent-runtime.md
@@ -1,0 +1,8 @@
+---
+"@isol8/core": minor
+"@isol8/cli": minor
+"@isol8/server": minor
+"@isol8/docs": minor
+---
+
+Add agent runtime for running sandboxed AI coding agents (pi) inside isol8 containers with network filtering and project file injection

--- a/.gitignore
+++ b/.gitignore
@@ -44,4 +44,4 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 
 # benchmark artifacts
 packages/core/benchmarks/results/
-docs/
+/docs/

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@
 [![npm](https://img.shields.io/npm/v/isol8)](https://www.npmjs.com/package/isol8)
 [![license](https://img.shields.io/npm/l/isol8)](./LICENSE)
 
-Secure code execution engine for AI agents. Run untrusted Python, Node.js, Bun, Deno, and Bash code inside locked-down Docker containers with network filtering, resource limits, and output controls.
+Secure code execution engine for AI agents. Run untrusted Python, Node.js, Bun, Deno, Bash, and AI agent code inside locked-down Docker containers with network filtering, resource limits, and output controls.
 
 ## Features
 
-- **5 runtimes** — Python, Node.js, Bun, Deno, Bash
+- **6 runtimes** — Python, Node.js, Bun, Deno, Bash, Agent (sandboxed AI coding agent)
 - **Ephemeral & persistent** — one-shot execution or stateful REPL-like sessions
 - **Streaming** — real-time output via `executeStream()` / SSE
 - **Fast** — warm container pool for sub-100ms execution latency
@@ -88,6 +88,30 @@ isol8 setup --node lodash,axios
 | `--bash <pkgs>` | Comma-separated Alpine apk packages |
 | `--force` | Force rebuild even if images are up to date |
 
+### Agent Runtime
+
+The `agent` runtime runs an AI coding agent ([pi](https://github.com/mariozechner/pi-coding-agent)) inside an isol8 sandbox. The `-e` flag provides the prompt text, and the agent operates on files injected via `--files`.
+
+**Requirements:**
+- `--net filtered` with at least one `--allow` entry (the agent needs API access)
+- `--secret` to pass the LLM provider API key
+
+**Defaults when `runtime=agent`:**
+- `pidsLimit`: 200 (vs 64 for other runtimes)
+- `sandboxSize`: 2g (vs 512m for other runtimes)
+
+```bash
+isol8 run \
+  -e "add comprehensive error handling to all API endpoints" \
+  --runtime agent \
+  --net filtered --allow "api.anthropic.com" \
+  --secret "ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY" \
+  --files ./my-project \
+  --workdir /sandbox/my-project \
+  --timeout 600000 \
+  --agent-flags "--model claude-sonnet-4-20250514 --thinking"
+```
+
 ### `isol8 run`
 
 Execute code in isol8. Accepts a file, `--eval`, or stdin.
@@ -107,12 +131,18 @@ isol8 run -e "import numpy; print(numpy.__version__)" --install numpy --runtime 
 
 # Remote execution
 isol8 run script.py --host http://server:3000 --key my-api-key
+
+# AI coding agent (requires --net filtered + --allow)
+isol8 run -e "refactor this module to use async/await" --runtime agent \
+  --net filtered --allow "api.anthropic.com" \
+  --secret "ANTHROPIC_API_KEY=sk-..." \
+  --files ./my-project --workdir /sandbox/my-project --timeout 600000
 ```
 
 | Flag | Description | Default |
 |------|-------------|---------|
 | `-e, --eval <code>` | Execute inline code | — |
-| `-r, --runtime <rt>` | Force runtime: `python`, `node`, `bun`, `deno`, `bash` | auto-detect |
+| `-r, --runtime <rt>` | Force runtime: `python`, `node`, `bun`, `deno`, `bash`, `agent` | auto-detect |
 | `--net <mode>` | Network mode: `none`, `host`, `filtered` | `none` (unless `--install` is used without explicit `--net`, then auto `filtered`) |
 | `--allow <regex>` | Whitelist regex (repeatable, for `filtered`) | — |
 | `--deny <regex>` | Blacklist regex (repeatable, for `filtered`) | — |
@@ -140,6 +170,8 @@ isol8 run script.py --host http://server:3000 --key my-api-key
 | `--gist <gistId/file.ext>` | Gist shorthand for raw source | — |
 | `--hash <sha256>` | Verify SHA-256 hash for fetched code | — |
 | `--allow-insecure-code-url` | Allow insecure `http://` code URLs for this request | `false` |
+| `--agent-flags <flags>` | Extra flags for the `pi` agent (e.g. `--model`, `--thinking`), agent runtime only | — |
+| `--files <dir>` | Inject a local directory recursively into `/sandbox` (skips `.git`, `node_modules`, etc.) | — |
 | `--host <url>` | Remote server URL | — |
 | `--key <key>` | API key for remote server | `$ISOL8_API_KEY` |
 

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -4,13 +4,15 @@ import {
   chmodSync,
   existsSync,
   mkdirSync,
+  readdirSync,
   readFileSync,
   renameSync,
+  statSync,
   unlinkSync,
   writeFileSync,
 } from "node:fs";
 import { arch, homedir, platform } from "node:os";
-import { join, resolve } from "node:path";
+import { join, relative, resolve } from "node:path";
 import type {
   ExecutionRequest,
   Isol8Engine,
@@ -321,6 +323,11 @@ program
   .option("--debug", "Enable debug logging")
   .option("--persist", "Keep container running after execution for inspection")
   .option("--log-network", "Log all network requests (requires --net filtered)")
+  .option(
+    "--agent-flags <flags>",
+    "Extra CLI flags for the agent runtime (e.g. --model, --thinking)"
+  )
+  .option("--files <dir>", "Inject a local directory into the container at /sandbox")
   .action(async (file: string | undefined, opts) => {
     const {
       code,
@@ -399,8 +406,21 @@ program
             }
           : {}),
         ...(opts.workdir ? { workdir: opts.workdir } : {}),
+        ...(opts.agentFlags ? { agentFlags: opts.agentFlags } : {}),
         fileExtension,
       };
+
+      // Inject local directory into the container when --files is specified
+      if (opts.files) {
+        const filesDir = resolve(opts.files);
+        if (!(existsSync(filesDir) && statSync(filesDir).isDirectory())) {
+          console.error(`[ERR] --files path is not a directory: ${opts.files}`);
+          process.exit(1);
+        }
+        const injectedFiles = readDirectoryRecursive(filesDir);
+        req.files = { ...req.files, ...injectedFiles };
+        logger.debug(`[Run] Injected ${Object.keys(injectedFiles).length} files from ${filesDir}`);
+      }
 
       // Stream by default unless --no-stream is passed
       if (opts.stream !== false) {
@@ -1448,6 +1468,19 @@ async function resolveRunInput(file: string | undefined, opts: any) {
     );
   }
 
+  // Agent runtime defaults: higher pidsLimit (pi spawns subprocesses) and
+  // larger sandbox (agent projects need more disk space).
+  if (runtime === "agent") {
+    if (!opts.pidsLimit) {
+      engineOptions.pidsLimit = 200;
+      logger.debug("[Run] Agent runtime: defaulting pidsLimit to 200");
+    }
+    if (!opts.sandboxSize) {
+      engineOptions.sandboxSize = "2g";
+      logger.debug("[Run] Agent runtime: defaulting sandboxSize to 2g");
+    }
+  }
+
   // If package installation is requested in filtered mode, extend whitelist
   // with runtime package registry hosts so installs can resolve dependencies.
   if (opts.install.length > 0 && engineOptions.network === "filtered") {
@@ -1564,7 +1597,7 @@ function parseRuntimeName(value: string): Runtime {
     return RuntimeRegistry.get(value).name;
   } catch {
     console.error(
-      `[ERR] Invalid runtime: ${value}. Expected one of: python, node, bun, deno, bash`
+      `[ERR] Invalid runtime: ${value}. Expected one of: python, node, bun, deno, bash, agent`
     );
     process.exit(1);
   }
@@ -1582,12 +1615,43 @@ function getDefaultRegistryAllowPatterns(runtime: Runtime): string[] {
       return ["^pypi\\.org$", "^files\\.pythonhosted\\.org$"];
     case "node":
     case "bun":
+    case "agent":
       return ["^registry\\.npmjs\\.org$"];
     case "bash":
       return ["^dl-cdn\\.alpinelinux\\.org$"];
     default:
       return [];
   }
+}
+
+/**
+ * Directories to skip when recursively reading a local directory for --files injection.
+ */
+const SKIP_DIRS = new Set([".git", "node_modules", "__pycache__", ".venv", "venv", ".tox"]);
+
+/**
+ * Recursively read a directory and return a map of container paths to file contents.
+ * Keys are absolute paths under /sandbox (e.g. `/sandbox/src/index.ts`).
+ */
+function readDirectoryRecursive(baseDir: string, currentDir?: string): Record<string, Buffer> {
+  const dir = currentDir ?? baseDir;
+  const files: Record<string, Buffer> = {};
+
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (SKIP_DIRS.has(entry.name)) {
+        continue;
+      }
+      Object.assign(files, readDirectoryRecursive(baseDir, fullPath));
+    } else if (entry.isFile()) {
+      const relPath = relative(baseDir, fullPath);
+      const containerPath = `/sandbox/${relPath}`;
+      files[containerPath] = readFileSync(fullPath);
+    }
+  }
+
+  return files;
 }
 
 function collect(value: string, previous: string[]): string[] {

--- a/apps/cli/tests/integration/agent.test.ts
+++ b/apps/cli/tests/integration/agent.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, test } from "bun:test";
+import { DockerIsol8 } from "@isol8/core";
+import { hasDocker } from "./setup";
+
+/**
+ * Integration tests for the agent runtime.
+ *
+ * These tests verify the agent Docker image (isol8:agent) works correctly
+ * inside real containers. Since we cannot make actual LLM API calls in tests,
+ * we test:
+ * - The pi binary is accessible and runnable
+ * - The container has required tools (bun, git, bash)
+ * - The agent validation logic (filtered network + whitelist required)
+ * - Command construction and flag passing
+ * - File injection via the files option
+ */
+describe("Integration: Agent Runtime", () => {
+  if (!hasDocker) {
+    test.skip("Docker not available", () => {});
+    return;
+  }
+
+  // ── Validation Tests ──
+
+  test("Agent runtime rejects network: 'none'", async () => {
+    const engine = new DockerIsol8({
+      mode: "ephemeral",
+      network: "none",
+    });
+
+    await expect(
+      engine.execute({
+        code: "Write hello world",
+        runtime: "agent",
+      })
+    ).rejects.toThrow('Agent runtime requires network mode "filtered"');
+  }, 30_000);
+
+  test("Agent runtime rejects filtered network without whitelist", async () => {
+    const engine = new DockerIsol8({
+      mode: "ephemeral",
+      network: "filtered",
+      networkFilter: {
+        whitelist: [],
+        blacklist: [],
+      },
+    });
+
+    await expect(
+      engine.execute({
+        code: "Write hello world",
+        runtime: "agent",
+      })
+    ).rejects.toThrow("Agent runtime requires at least one network whitelist entry");
+  }, 30_000);
+
+  // ── Container Environment Tests ──
+  // These use bash runtime with the agent image override to verify the container contents
+
+  test("Agent container has pi binary available", async () => {
+    const engine = new DockerIsol8({
+      mode: "ephemeral",
+      network: "none",
+      image: "isol8:agent",
+    });
+
+    const result = await engine.execute({
+      code: "pi --version",
+      runtime: "bash",
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toMatch(/^\d+\.\d+\.\d+$/);
+  }, 30_000);
+
+  test("Agent container has bun available", async () => {
+    const engine = new DockerIsol8({
+      mode: "ephemeral",
+      network: "none",
+      image: "isol8:agent",
+    });
+
+    const result = await engine.execute({
+      code: "bun --version",
+      runtime: "bash",
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toMatch(/^\d+\.\d+\.\d+$/);
+  }, 30_000);
+
+  test("Agent container has git available", async () => {
+    const engine = new DockerIsol8({
+      mode: "ephemeral",
+      network: "none",
+      image: "isol8:agent",
+    });
+
+    const result = await engine.execute({
+      code: "git --version",
+      runtime: "bash",
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("git version");
+  }, 30_000);
+
+  test("Agent container has bash available", async () => {
+    const engine = new DockerIsol8({
+      mode: "ephemeral",
+      network: "none",
+      image: "isol8:agent",
+    });
+
+    const result = await engine.execute({
+      code: "bash --version",
+      runtime: "bash",
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("GNU bash");
+  }, 30_000);
+
+  // ── pi CLI Behavior Tests (no API key needed) ──
+
+  test("pi --help runs without error", async () => {
+    const engine = new DockerIsol8({
+      mode: "ephemeral",
+      network: "none",
+      image: "isol8:agent",
+    });
+
+    const result = await engine.execute({
+      code: "pi --help",
+      runtime: "bash",
+    });
+
+    // pi --help should output help text and exit 0
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.length).toBeGreaterThan(0);
+  }, 30_000);
+
+  // ── File Injection Tests ──
+
+  test("Files are injected into the container sandbox", async () => {
+    const engine = new DockerIsol8({
+      mode: "ephemeral",
+      network: "none",
+      image: "isol8:agent",
+    });
+
+    const result = await engine.execute({
+      code: "cat /sandbox/hello.txt && cat /sandbox/world.txt",
+      runtime: "bash",
+      files: {
+        "/sandbox/hello.txt": "Hello from file injection!",
+        "/sandbox/world.txt": "Second file content",
+      },
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("Hello from file injection!");
+    expect(result.stdout).toContain("Second file content");
+  }, 30_000);
+
+  test("Injected files are readable by the sandbox user", async () => {
+    const engine = new DockerIsol8({
+      mode: "ephemeral",
+      network: "none",
+      image: "isol8:agent",
+    });
+
+    const result = await engine.execute({
+      code: 'ls -la /sandbox/test.py && echo "readable"',
+      runtime: "bash",
+      files: {
+        "/sandbox/test.py": 'print("hello")',
+      },
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("readable");
+  }, 30_000);
+});

--- a/apps/docs/agent-in-a-box.mdx
+++ b/apps/docs/agent-in-a-box.mdx
@@ -1,0 +1,311 @@
+---
+title: "Agent in a Box"
+description: "Run a full coding agent — pi — inside an isol8 sandbox. Give an LLM a filesystem, tools, and controlled network access in a single execute() call."
+icon: "microchip-ai"
+---
+
+The `agent` runtime runs the [pi coding agent](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent) (`@mariozechner/pi-coding-agent`) inside an isol8 container. Instead of executing code, it executes a **prompt** — pi handles the LLM loop, tool calls (`read`, `write`, `edit`, `bash`), and file edits autonomously, entirely within the sandbox.
+
+## Quick start
+
+<Tabs>
+  <Tab title="CLI">
+    ```bash
+    isol8 run -e "add unit tests for the auth module" \
+      --runtime agent \
+      --net filtered \
+      --allow "api.anthropic.com" \
+      --secret "ANTHROPIC_API_KEY=sk-ant-..." \
+      --agent-flags "--model anthropic/claude-sonnet-4-5"
+    ```
+  </Tab>
+  <Tab title="Library">
+    ```typescript
+    import { DockerIsol8 } from "@isol8/core";
+
+    const engine = new DockerIsol8({
+      network: "filtered",
+      networkFilter: {
+        whitelist: ["^api\\.anthropic\\.com$"],
+        blacklist: [],
+      },
+    });
+
+    await engine.start();
+
+    const result = await engine.execute({
+      runtime: "agent",
+      code: "add unit tests for the auth module",
+      agentFlags: "--model anthropic/claude-sonnet-4-5",
+      env: { ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY! },
+      timeoutMs: 300_000,
+    });
+
+    console.log(result.stdout);
+    await engine.stop();
+    ```
+  </Tab>
+  <Tab title="API">
+    ```bash
+    curl -X POST http://localhost:3000/execute \
+      -H "Authorization: Bearer $ISOL8_API_KEY" \
+      -H "Content-Type: application/json" \
+      -d '{
+        "request": {
+          "runtime": "agent",
+          "code": "add unit tests for the auth module",
+          "agentFlags": "--model anthropic/claude-sonnet-4-5",
+          "env": { "ANTHROPIC_API_KEY": "sk-ant-..." }
+        },
+        "options": {
+          "network": "filtered",
+          "networkFilter": {
+            "whitelist": ["^api\\.anthropic\\.com$"],
+            "blacklist": []
+          },
+          "timeoutMs": 300000
+        }
+      }'
+    ```
+  </Tab>
+</Tabs>
+
+## How it works
+
+When `runtime: "agent"` is used, isol8 runs:
+
+```
+pi --no-session --append-system-prompt '<sandbox context>' [agentFlags] -p '<code>'
+```
+
+- `--no-session` — disables session persistence (ephemeral, non-interactive)
+- `--append-system-prompt` — automatically injected by isol8 to inform pi of sandbox constraints
+- `agentFlags` — extra pi flags you supply (model, thinking level, tool restrictions)
+- `-p '<code>'` — your prompt, shell-quoted
+
+pi then runs its own tool-call loop inside the container. It can read, write, and edit files under `/sandbox`, and run arbitrary bash commands — all within the sandbox's resource and network limits.
+
+## Networking requirement
+
+The agent runtime **requires** `network: "filtered"` with at least one whitelist entry. Passing `network: "none"` throws:
+
+```
+Error: agent runtime requires network "filtered" with at least one whitelist entry.
+The agent needs access to an LLM API endpoint (e.g. "^api\\.anthropic\\.com$").
+```
+
+```typescript
+// Correct
+const engine = new DockerIsol8({
+  network: "filtered",
+  networkFilter: {
+    whitelist: ["^api\\.anthropic\\.com$"],
+    blacklist: ["^169\\.254\\."],
+  },
+});
+```
+
+## Sandbox system prompt
+
+Every pi invocation inside isol8 receives an automatically appended system prompt informing the agent that it is running in a sandbox with restricted network access and an ephemeral filesystem. This uses pi's `--append-system-prompt` — it appends to pi's default prompt without replacing it. You do not need to supply this yourself.
+
+## The `code` field
+
+For the agent runtime, `code` is always the **prompt text** — never a script. It is passed to pi via `-p '<prompt>'` after shell-quoting.
+
+```typescript
+await engine.execute({
+  runtime: "agent",
+  code: "Refactor authenticate() to use async/await and add JSDoc comments.",
+});
+```
+
+## Agent flags (`agentFlags`)
+
+Use `agentFlags` (library/API) or `--agent-flags` (CLI) to pass extra arguments to `pi` before the `-p` flag.
+
+```typescript
+await engine.execute({
+  runtime: "agent",
+  code: "Fix the failing tests",
+  agentFlags: "--model anthropic/claude-sonnet-4-5 --thinking medium --no-extensions",
+});
+```
+
+### Useful pi flags
+
+| Flag | Description |
+|:---|:---|
+| `--model <provider/id>` | LLM to use — e.g. `anthropic/claude-sonnet-4-5`, `openai/gpt-4o`, `google/gemini-2.0-flash` |
+| `--thinking <level>` | Thinking budget: `off`, `minimal`, `low`, `medium`, `high`, `xhigh` |
+| `--tools <list>` | Built-in tools to enable. Default: `read,bash,edit,write`. Also: `grep`, `find`, `ls` |
+| `--no-tools` | Disable all built-in tools |
+| `--no-skills` | Disable auto-loading of skill files from the container |
+| `--no-extensions` | Disable auto-loading of extensions from the container |
+
+## Injecting files
+
+Use `files` in `ExecutionRequest` (library/API) or `--files <dir>` (CLI) to inject local files into `/sandbox` before the agent runs.
+
+<Tabs>
+  <Tab title="Library">
+    ```typescript
+    import { readFileSync } from "node:fs";
+
+    await engine.execute({
+      runtime: "agent",
+      code: "Review the code in /sandbox and suggest improvements to error handling",
+      agentFlags: "--model anthropic/claude-sonnet-4-5 --tools read,bash",
+      files: {
+        "src/auth.ts": readFileSync("./src/auth.ts", "utf-8"),
+        "src/utils.ts": readFileSync("./src/utils.ts", "utf-8"),
+        // pi auto-loads AGENTS.md from cwd — use this for project rules
+        "AGENTS.md": "# Rules\n- Follow existing code style\n- No new dependencies\n",
+      },
+    });
+    ```
+  </Tab>
+  <Tab title="CLI">
+    ```bash
+    # Inject an entire local directory into /sandbox
+    isol8 run -e "Review the code and suggest improvements" \
+      --runtime agent \
+      --files ./src \
+      --net filtered \
+      --allow "api.anthropic.com"
+    ```
+  </Tab>
+</Tabs>
+
+<Tip>
+  pi automatically loads `AGENTS.md` (and `CLAUDE.md`) from the working directory at startup. Injecting your project rules as `/sandbox/AGENTS.md` gives the agent project-specific context without touching the prompt.
+</Tip>
+
+## Persistent sessions
+
+Use `mode: "persistent"` to run multiple steps in the same container — for example, cloning a repo with bash and then running the agent against it:
+
+```typescript
+const engine = new DockerIsol8({
+  mode: "persistent",
+  network: "filtered",
+  networkFilter: {
+    whitelist: ["^api\\.anthropic\\.com$", "^github\\.com$"],
+    blacklist: [],
+  },
+  secrets: {
+    GITHUB_TOKEN: process.env.GITHUB_TOKEN!,
+    ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY!,
+  },
+  pidsLimit: 200,
+  memoryLimit: "2g",
+});
+
+await engine.start();
+
+// Step 1: deterministic setup (bash)
+await engine.execute({
+  runtime: "bash",
+  code: `
+    git clone https://$GITHUB_TOKEN@github.com/my-org/my-repo.git /sandbox/repo
+    cd /sandbox/repo && git checkout -b agent/task origin/main
+  `,
+});
+
+// Step 2: agentic implementation (agent)
+await engine.execute({
+  runtime: "agent",
+  code: "Fix the type errors in src/parser.ts. The project uses TypeScript strict mode.",
+  agentFlags: "--model anthropic/claude-sonnet-4-5 --thinking low",
+  env: { ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY! },
+  timeoutMs: 300_000,
+});
+
+// Step 3: deterministic verification (bash)
+const testResult = await engine.execute({
+  runtime: "bash",
+  code: "cd /sandbox/repo && npx tsc --noEmit && npx jest --ci",
+});
+
+await engine.stop();
+```
+
+## Streaming agent output
+
+pi produces output incrementally. Use `executeStream` to receive it in real-time:
+
+```typescript
+for await (const event of engine.executeStream({
+  runtime: "agent",
+  code: "Refactor the auth module to remove deprecated API calls",
+  agentFlags: "--model anthropic/claude-sonnet-4-5",
+})) {
+  if (event.type === "stdout") process.stdout.write(event.data);
+  if (event.type === "stderr") process.stderr.write(event.data);
+  if (event.type === "exit") console.log(`\nAgent exited: ${event.data}`);
+}
+```
+
+## Default resource limits
+
+The agent runtime applies higher defaults than other runtimes since pi spawns subprocesses for tool calls:
+
+| Option | Agent default | Other runtimes |
+|:---|:---|:---|
+| `pidsLimit` | `200` | `64` |
+| `sandboxSize` | `2g` | `512m` |
+
+## Retrieving output files
+
+Use `outputPaths` to include files written by the agent in the result:
+
+```typescript
+const result = await engine.execute({
+  runtime: "agent",
+  code: "Generate a test suite for the Parser class and write it to /sandbox/parser.test.ts",
+  outputPaths: ["/sandbox/parser.test.ts"],
+});
+
+console.log(result.files?.["/sandbox/parser.test.ts"]);
+```
+
+Or retrieve files explicitly with `getFile()` after execution in a persistent session.
+
+## LLM API key handling
+
+Pass the API key via engine `secrets` (recommended — masked from output) or per-request `env`:
+
+```typescript
+// Via engine secrets — automatically masked in stdout/stderr
+const engine = new DockerIsol8({
+  secrets: { ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY! },
+  // ...
+});
+```
+
+## Troubleshooting
+
+**`Error: agent runtime requires network "filtered"`** — Switch to `network: "filtered"` and add an LLM API endpoint to the whitelist.
+
+**Agent exits non-zero** — Check `result.stderr`. Common causes: missing API key, endpoint not in whitelist, `timeoutMs` too short.
+
+**Agent can't reach the LLM API** — Verify the whitelist pattern is anchored (`^api\\.anthropic\\.com$`). A missing `^` or `$` won't match as expected.
+
+**Files not in result** — Add `outputPaths` or call `getFile()` after the run. In ephemeral mode, container state is discarded on exit.
+
+## Related pages
+
+<CardGroup cols={2}>
+  <Card title="One-shot coding agents" icon="wand-magic-sparkles" href="/guides/one-shot-coding-agents">
+    End-to-end blueprint: clone repo, implement, lint, test, create PR — using the agent runtime.
+  </Card>
+  <Card title="AI agent code execution" icon="robot" href="/guides/ai-agents">
+    Foundational patterns for LLM tool-call loops with isol8.
+  </Card>
+  <Card title="Runtime reference" icon="layer-group" href="/runtimes">
+    All six runtimes: commands, extensions, package install behavior.
+  </Card>
+  <Card title="Security model" icon="shield-check" href="/security">
+    Network controls, seccomp, secret masking, and isolation boundaries.
+  </Card>
+</CardGroup>

--- a/apps/docs/cli.mdx
+++ b/apps/docs/cli.mdx
@@ -37,8 +37,8 @@ isol8 run [file] [options]
   Inline code to execute.
 </ResponseField>
 
-<ResponseField name="-r, --runtime <name>" type="python | node | bun | deno | bash">
-  Force runtime instead of extension-based detection.
+<ResponseField name="-r, --runtime <name>" type="python | node | bun | deno | bash | agent">
+  Force runtime instead of extension-based detection. The `agent` runtime must always be specified explicitly (no file extension mapping).
 </ResponseField>
 
 <ResponseField name="--stdin <data>" type="string">
@@ -133,6 +133,15 @@ isol8 run [file] [options]
   Inject secret env vars and mask values in output.
 </ResponseField>
 
+<ResponseField name="--agent-flags <flags>" type="string">
+  Extra flags passed to the `pi` coding agent before the prompt. Only valid with `--runtime agent`.
+  Common flags: `--model <name>`, `--thinking`, `--max-tokens <n>`.
+</ResponseField>
+
+<ResponseField name="--files <dir>" type="string">
+  Recursively inject a local directory into the container under `/sandbox`. Skips `.git`, `node_modules`, `__pycache__`, `.venv`, `venv`, and `.tox` directories. Useful with the `agent` runtime to provide project files for the agent to work on.
+</ResponseField>
+
 <ResponseField name="--out <file>" type="string">
   Write stdout to local file.
 </ResponseField>
@@ -203,6 +212,25 @@ isol8 run \
   --session-id my-session \
   --host http://localhost:3000 \
   --key my-key
+
+# AI coding agent
+isol8 run \
+  -e "add error handling to all API endpoints" \
+  --runtime agent \
+  --net filtered --allow "api.anthropic.com" \
+  --secret "ANTHROPIC_API_KEY=sk-..." \
+  --files ./my-project \
+  --workdir /sandbox/my-project \
+  --timeout 600000
+
+# Agent with extra pi flags
+isol8 run \
+  -e "refactor auth module" \
+  --runtime agent \
+  --net filtered --allow "api.anthropic.com" \
+  --secret "ANTHROPIC_API_KEY=sk-..." \
+  --files ./src \
+  --agent-flags "--model claude-sonnet-4-20250514 --thinking"
 ```
 
 ## `isol8 setup`
@@ -526,6 +554,10 @@ isol8 cleanup [options]
   Streaming is the default behavior. Use `--no-stream` if you want buffered output only after the run completes.
 </Accordion>
 
+<Accordion title="What is the agent runtime?">
+  The `agent` runtime runs the [pi coding agent](https://github.com/mariozechner/pi-coding-agent) inside an isol8 sandbox. The `-e` value is treated as the prompt, not code. It requires `--net filtered` with an `--allow` entry for the LLM API, and an API key via `--secret`. The CLI automatically raises `pidsLimit` to 200 and `sandboxSize` to 2g for agent runs.
+</Accordion>
+
 ## Troubleshooting quick checks
 
 - **`[ERR] --session-id requires --host`**: `--session-id` is a server feature; add `--host <url>`.
@@ -535,6 +567,8 @@ isol8 cleanup [options]
 - **Runtime not detected from file extension**: pass `--runtime <name>` explicitly.
 - **No output appears while command runs**: check if `--no-stream` is enabled.
 - **Filtered mode still blocks host**: verify `--allow` regex matches hostname exactly.
+- **Agent runtime fails with network error**: ensure `--net filtered` and `--allow` are set. The agent runtime enforces filtered networking with at least one whitelist entry.
+- **Agent runtime out of disk space**: increase `--sandbox-size` (default 2g for agent). Large repos may need 4g+.
 
 ## See also
 

--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -123,6 +123,7 @@
             "pages": [
               "guides/persistent-execution",
               "guides/ai-agents",
+              "guides/one-shot-coding-agents",
               "guides/data-processing",
               "guides/web-scraping",
               "guides/education"

--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -51,6 +51,7 @@
             "pages": [
               "execution",
               "runtimes",
+              "agent-in-a-box",
               "security",
               "file-systems",
               "persistence",

--- a/apps/docs/execution.mdx
+++ b/apps/docs/execution.mdx
@@ -27,7 +27,7 @@ flowchart TD
 ```
 
 <Note>
-  In ephemeral mode, simple requests can skip file injection and execute inline (for example `python -c`, `node -e`, `bun -e`, `bash -c`) when no `stdin`, `files`, `outputPaths`, or package installs are requested.
+  In ephemeral mode, simple requests can skip file injection and execute inline (for example `python -c`, `node -e`, `bun -e`, `bash -c`) when no `stdin`, `files`, `outputPaths`, or package installs are requested. The `agent` runtime always uses file injection and passes the code as a prompt to the pi coding agent.
 </Note>
 
 ## Execution Modes
@@ -237,11 +237,18 @@ Inject files *before* execution and retrieve them *after*.
 <Tabs>
   <Tab title="CLI">
     <Note>
-      The CLI does not currently support generic file injection (`files`) or retrieval (`outputPaths`). It can only capture `stdout` to a file using `--out`.
+      The CLI supports file injection for the `agent` runtime via `--files <dir>`, which recursively copies a local directory into `/sandbox`. For other runtimes, use the Library or API for generic file injection (`files`) or retrieval (`outputPaths`). All runtimes support `--out` to capture stdout to a file.
     </Note>
 
     ```bash
+    # Capture stdout to file
     isol8 run script.py --out result.txt
+
+    # Inject project files for agent runtime
+    isol8 run -e "add tests" --runtime agent \
+      --files ./my-project \
+      --net filtered --allow "api.anthropic.com" \
+      --secret "ANTHROPIC_API_KEY=sk-..."
     ```
   </Tab>
   <Tab title="Library">

--- a/apps/docs/guides/ai-agents.mdx
+++ b/apps/docs/guides/ai-agents.mdx
@@ -8,6 +8,7 @@ Use this guide when your LLM needs a reliable code-execution tool and you want s
 
 ## Diagram: Agent execution loop
 
+{/* prettier-ignore */}
 ```mermaid
 flowchart TD
   A["User asks question"] --> B["LLM plans code"]
@@ -15,7 +16,7 @@ flowchart TD
   C --> D["isol8 sandbox execution"]
   D --> E["stdout/stderr/exitCode"]
   E --> F["LLM reasons on result"]
-  F --> G{"Need another run?"}
+  F --> G{{"Need another run?"}}
   G -->|Yes| B
   G -->|No| H["Final answer"]
 ```

--- a/apps/docs/guides/one-shot-coding-agents.mdx
+++ b/apps/docs/guides/one-shot-coding-agents.mdx
@@ -175,28 +175,25 @@ if (cloneResult.exitCode !== 0) {
 }
 ```
 
-Inject rule files and task context. pi automatically loads `AGENTS.md` (and `CLAUDE.md`) from the working directory at startup — injecting your rules there is the recommended pattern:
+pi automatically loads `AGENTS.md` (and `CLAUDE.md`) from the working directory at startup. Inject your project-level rules there so pi picks them up without any prompt engineering:
 
 ```typescript
 // Inject project-specific agent rules — pi auto-loads AGENTS.md from cwd
 const rulesContent = await fs.readFile("./agent-rules/python-rules.md", "utf-8");
 await engine.putFile("/sandbox/repo/AGENTS.md", rulesContent);
+```
 
-// Inject a task-specific context file referenced in the prompt
-await engine.putFile("/sandbox/repo/TASK.md", `
-# Task
-Fix the type error in src/utils/parser.ts described in issue #42.
+The task description itself goes directly in the `code` field (the prompt) — no need to write it to a file:
 
-# Rules
-- Follow existing code style (prettier + eslint enforced)
-- Write tests for any new functions
-- Do not modify the public API surface
-- Commit messages should reference the issue number
-`);
+```typescript
+const task = `Fix the type error in src/utils/parser.ts described in issue #42.
+Follow existing code style, write tests for any new functions, and do not modify the public API surface.`;
+
+await agentImplement(task);
 ```
 
 <Tip>
-  When using the CLI instead of the library, use `--files <dir>` to inject an entire local directory into `/sandbox` in one shot. All files are mounted at their relative paths under `/sandbox`, skipping `.git`, `node_modules`, and `__pycache__`.
+  Use `--files <dir>` (CLI) or the `files` field in `ExecutionRequest` (library) when you need to inject a large local directory tree — e.g. your entire project source — into `/sandbox` before the agent runs. For small text blobs like rules or config, `putFile()` is simpler.
 </Tip>
 
 ## Step 4: Run the agent step
@@ -354,7 +351,7 @@ async function runMinion(task: string) {
 }
 
 // Run it
-runMinion("Fix the type error in src/utils/parser.ts described in issue #42. Context is in /sandbox/repo/TASK.md.");
+runMinion("Fix the type error in src/utils/parser.ts described in issue #42. Follow existing code style, write tests for any new functions, do not modify the public API surface.");
 ```
 
 ## Scaling with the remote server

--- a/apps/docs/guides/one-shot-coding-agents.mdx
+++ b/apps/docs/guides/one-shot-coding-agents.mdx
@@ -83,7 +83,13 @@ Define `prebuiltImages` in `isol8.config.json` so images are built automatically
     "network": "filtered"
   },
   "network": {
-    "whitelist": ["^github\\.com$", "^api\\.github\\.com$", "^registry\\.npmjs\\.org$", "^pypi\\.org$"],
+    "whitelist": [
+      "^api\\.anthropic\\.com$",
+      "^github\\.com$",
+      "^api\\.github\\.com$",
+      "^registry\\.npmjs\\.org$",
+      "^pypi\\.org$"
+    ],
     "blacklist": ["^169\\.254\\."]
   },
   "cleanup": {
@@ -118,14 +124,20 @@ const engine = new DockerIsol8({
   image: "my-org/python-devbox:latest",
   network: "filtered",
   networkFilter: {
-    // Allow LLM API access + package registries
-    whitelist: ["^api\\.anthropic\\.com$", "^github\\.com$", "^api\\.github\\.com$", "^pypi\\.org$"],
+    // LLM API access + VCS + package registries
+    whitelist: [
+      "^api\\.anthropic\\.com$",
+      "^github\\.com$",
+      "^api\\.github\\.com$",
+      "^pypi\\.org$",
+    ],
     blacklist: ["^169\\.254\\."],
   },
   timeoutMs: 300_000, // 5 minutes per step
   memoryLimit: "2g",
-  pidsLimit: 200,     // agent runtime spawns subprocesses
+  pidsLimit: 200,     // agent runtime spawns subprocesses; isol8 defaults this to 200 automatically
   secrets: {
+    // Passed as environment variables; values are automatically masked in stdout/stderr
     GITHUB_TOKEN: process.env.GITHUB_TOKEN!,
     ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY!,
   },
@@ -136,6 +148,10 @@ await engine.start();
 
 <Note>
   `mode: "persistent"` reuses a single container across all `execute()` calls, preserving filesystem state — just like Stripe's devboxes persist across agent steps.
+</Note>
+
+<Note>
+  The agent runtime **requires** `network: "filtered"` with at least one whitelist entry. Passing `network: "none"` or an empty whitelist throws immediately. Pass your LLM provider's domain (e.g. `^api\\.anthropic\\.com$`) in the whitelist.
 </Note>
 
 ## Step 3: Hydrate context (clone repo, inject rules)
@@ -157,9 +173,17 @@ const cloneResult = await engine.execute({
 if (cloneResult.exitCode !== 0) {
   throw new Error(`Clone failed: ${cloneResult.stderr}`);
 }
+```
 
-// Inject agent rules and task context as files
-await engine.putFile("/sandbox/repo/AGENT_CONTEXT.md", `
+Inject rule files and task context. pi automatically loads `AGENTS.md` (and `CLAUDE.md`) from the working directory at startup — injecting your rules there is the recommended pattern:
+
+```typescript
+// Inject project-specific agent rules — pi auto-loads AGENTS.md from cwd
+const rulesContent = await fs.readFile("./agent-rules/python-rules.md", "utf-8");
+await engine.putFile("/sandbox/repo/AGENTS.md", rulesContent);
+
+// Inject a task-specific context file referenced in the prompt
+await engine.putFile("/sandbox/repo/TASK.md", `
 # Task
 Fix the type error in src/utils/parser.ts described in issue #42.
 
@@ -171,21 +195,13 @@ Fix the type error in src/utils/parser.ts described in issue #42.
 `);
 ```
 
-You can also inject rule files, `.cursorrules`, `AGENTS.md`, or any context documents your agent needs:
-
-```typescript
-// Inject project-specific agent rules from your repo
-const rulesContent = await fs.readFile("./agent-rules/python-rules.md", "utf-8");
-await engine.putFile("/sandbox/repo/AGENTS.md", rulesContent);
-```
-
-<Note>
-  pi automatically loads `AGENTS.md` (and `CLAUDE.md`) from the working directory at startup. Injecting your rules as `/sandbox/repo/AGENTS.md` is the recommended way to supply project context.
-</Note>
+<Tip>
+  When using the CLI instead of the library, use `--files <dir>` to inject an entire local directory into `/sandbox` in one shot. All files are mounted at their relative paths under `/sandbox`, skipping `.git`, `node_modules`, and `__pycache__`.
+</Tip>
 
 ## Step 4: Run the agent step
 
-This is the agentic step — use `runtime: "agent"` to run the pi coding agent inside the sandbox. The `code` field is the prompt; pi handles the LLM loop, tool calls, and file edits autonomously.
+Use `runtime: "agent"` to run the pi coding agent inside the sandbox. The `code` field is the natural-language prompt — pi handles the full LLM loop, tool calls (`read`, `write`, `edit`, `bash`), and file edits autonomously inside the container.
 
 ```typescript
 async function agentImplement(task: string): Promise<ExecutionResult> {
@@ -194,30 +210,32 @@ async function agentImplement(task: string): Promise<ExecutionResult> {
     code: task,
     agentFlags: "--model anthropic/claude-sonnet-4-5 --thinking low",
     timeoutMs: 300_000,
-    env: {
-      // pi reads the LLM API key from the environment
-      ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY!,
-    },
+    // Do NOT pass ANTHROPIC_API_KEY here — it is already available
+    // via `secrets` in the engine config, and secrets are masked in output.
+    // Using per-request env bypasses masking.
   });
 }
 ```
 
 <Tip>
-  The agent runtime automatically appends a system prompt informing pi that it is running inside an isol8 sandbox with restricted network access and an ephemeral filesystem. You do not need to add this yourself.
+  Always pass LLM API keys via `secrets` in the engine config, not in per-request `env`. Keys in `secrets` are automatically redacted from stdout/stderr; keys in `env` are not.
 </Tip>
 
-The `agentFlags` field passes arguments directly to the `pi` CLI before `-p`. Useful flags:
+isol8 automatically appends a sandbox-awareness system prompt to pi's default prompt via `--append-system-prompt`. You do not need to tell pi it is in a container.
+
+The `agentFlags` field passes extra arguments to the `pi` CLI before `-p`. Useful flags:
 
 | Flag | Description |
 |:---|:---|
 | `--model <provider/id>` | LLM to use (e.g. `anthropic/claude-sonnet-4-5`, `openai/gpt-4o`) |
 | `--thinking <level>` | Thinking budget: `off`, `minimal`, `low`, `medium`, `high`, `xhigh` |
+| `--tools <list>` | Limit built-in tools (default: `read,bash,edit,write`) |
+| `--no-tools` | Disable all built-in tools (prompt-only mode) |
 | `--no-skills` | Disable auto-loading of skill files |
 | `--no-extensions` | Disable auto-loading of extensions |
-| `--tools <list>` | Limit built-in tools (default: `read,bash,edit,write`) |
 
 <Warning>
-  The agent runtime enforces `network: "filtered"` — it will throw if you pass `network: "none"` or `network: "host"`. The whitelist must include at least one LLM API endpoint (e.g. `^api\\.anthropic\\.com$`).
+  The agent runtime enforces `network: "filtered"` at both `execute()` and `executeStream()` call sites. Passing `network: "none"` or `network: "host"` — or an empty whitelist — throws before any container work begins.
 </Warning>
 
 ## Step 5: Deterministic lint and test steps
@@ -336,7 +354,7 @@ async function runMinion(task: string) {
 }
 
 // Run it
-runMinion("Fix the type error in src/utils/parser.ts described in issue #42");
+runMinion("Fix the type error in src/utils/parser.ts described in issue #42. Context is in /sandbox/repo/TASK.md.");
 ```
 
 ## Scaling with the remote server
@@ -365,6 +383,7 @@ async function spawnAgent(task: string) {
       sessionId,
     },
     {
+      mode: "persistent",
       image: "my-org/python-devbox:latest",
       network: "filtered",
       networkFilter: {
@@ -430,7 +449,7 @@ for await (const event of engine.executeStream({
 | MCP tools (Toolshed) | `network: "filtered"` allowing agent to call external APIs |
 | Local lint loop (pre-push hooks) | Deterministic lint step with `runtime: "bash"` before push |
 | CI feedback loop (at most 2 rounds) | Test step looped with `MAX_CI_ROUNDS` + agent fix step |
-| Secret isolation (no prod credentials) | `secrets` option with automatic output masking |
+| Secret isolation (no prod credentials) | `secrets` option — values are automatically masked in output |
 | Parallelization (many devboxes) | Multiple `RemoteIsol8` sessions via centralized server |
 
 ## Security considerations
@@ -440,11 +459,11 @@ Stripe isolates their devboxes from production. isol8 provides equivalent guardr
 - **Read-only root filesystem** — agents can only write to `/sandbox` and `/tmp`
 - **Non-root execution** — all code runs as `sandbox` user (uid 100)
 - **Network filtering** — allowlist only the hosts your agent needs (LLM APIs, GitHub, package registries)
-- **Secret masking** — credentials passed via `secrets` are automatically redacted from stdout/stderr
+- **Secret masking** — credentials in `secrets` are automatically redacted from stdout/stderr
 - **Resource limits** — CPU, memory, PIDs, and output size caps prevent runaway agents
-- **Seccomp profiles** — strict syscall filtering by default
+- **Seccomp profiles** — strict syscall filtering applied by default
 - **Session isolation** — each agent session is a separate container with no shared state
-- **Sandbox-aware system prompt** — isol8 automatically injects a system prompt informing pi of the sandbox constraints, so the agent doesn't attempt operations that will fail
+- **Sandbox-aware system prompt** — isol8 appends a prompt informing pi of sandbox constraints, so the agent doesn't attempt operations that will fail
 
 ```typescript
 const engine = new DockerIsol8({
@@ -452,7 +471,11 @@ const engine = new DockerIsol8({
   image: "my-org/node-devbox:latest",
   network: "filtered",
   networkFilter: {
-    whitelist: ["^api\\.anthropic\\.com$", "^github\\.com$", "^registry\\.npmjs\\.org$"],
+    whitelist: [
+      "^api\\.anthropic\\.com$",
+      "^github\\.com$",
+      "^registry\\.npmjs\\.org$",
+    ],
     blacklist: ["^169\\.254\\.", "^10\\.", "^172\\.(1[6-9]|2[0-9]|3[01])\\."],
   },
   secrets: {
@@ -473,7 +496,7 @@ const engine = new DockerIsol8({
 3. **Bake dependencies into images** — don't waste agent time installing packages. Use `prebuiltImages` to pre-install everything.
 4. **Scope context tightly** — inject only relevant rule files and documentation as `AGENTS.md`. Don't dump your entire codebase.
 5. **Deterministic where possible** — lint, format, test, commit, and push are deterministic steps. Don't let the LLM do what a shell script can do better.
-6. **Isolate by default** — the agent runtime requires `network: "filtered"`. Whitelist only what the agent genuinely needs.
+6. **Use `secrets` for API keys** — never pass LLM credentials via per-request `env`; use `secrets` so they are masked in output.
 7. **Use setup scripts** — bake recurring setup (git config, SSH, tool configuration) into the custom image's `setupScript` so it runs automatically before the agent starts.
 
 ## Related pages

--- a/apps/docs/guides/one-shot-coding-agents.mdx
+++ b/apps/docs/guides/one-shot-coding-agents.mdx
@@ -1,0 +1,518 @@
+---
+title: "One-shot coding agents"
+description: "Build unattended, one-shot coding agents — like Stripe's Minions — using isol8 custom images as isolated developer environments."
+icon: "wand-magic-sparkles"
+---
+
+Stripe's [Minions](https://stripe.dev/blog/minions-stripes-one-shot-end-to-end-coding-agents) are unattended coding agents that one-shot tasks end to end: a developer kicks one off, and it produces a complete pull request with no human code — only human review. Over 1,300 PRs merge at Stripe each week this way.
+
+The architecture behind Minions has three pillars:
+
+1. **Isolated, pre-warmed developer environments** — each agent run gets its own sandbox with tools, repos, and dependencies ready to go.
+2. **A blueprint-driven agent loop** — deterministic steps (lint, test, push) interleaved with agentic LLM steps (implement, fix failures).
+3. **Context hydration** — rule files, MCP tools, and documentation injected before the agent starts.
+
+isol8 gives you pillar 1 out of the box, and the building blocks to wire up pillars 2 and 3. This guide walks through the full setup using **custom images** as your pre-warmed devboxes.
+
+## Architecture overview
+
+{/* prettier-ignore */}
+```mermaid
+flowchart TD
+  A["Task input (Slack, ticket, CLI)"] --> B["Orchestrator"]
+  B --> C["Build / select custom image"]
+  C --> D["isol8 persistent session"]
+  D --> E["Setup: clone repo, hydrate context"]
+  E --> F["Agent loop: implement task"]
+  F --> G{{"Lint locally"}}
+  G -->|Fail| F
+  G -->|Pass| H["Push + run CI"]
+  H --> I{{"CI passes?"}}
+  I -->|Fail round 1| J["Agent loop: fix CI failures"]
+  J --> H
+  I -->|Pass or round 2| K["Create PR for human review"]
+```
+
+## Step 1: Build a custom devbox image
+
+Stripe pre-warms EC2 "devboxes" with repos, caches, and tools. With isol8, **custom images** serve the same purpose — a Docker image with your project's dependencies baked in so every agent run starts instantly.
+
+### CLI approach
+
+```bash
+# Build a Python data-science devbox
+isol8 build \
+  --base python \
+  --install numpy pandas scikit-learn pytest black ruff \
+  --setup "git config --global user.name 'agent' && git config --global user.email 'agent@ci'" \
+  --tag my-org/python-devbox:latest
+
+# Build a Node.js fullstack devbox
+isol8 build \
+  --base node \
+  --install typescript eslint prettier jest \
+  --tag my-org/node-devbox:latest
+```
+
+The `--setup` flag bakes a shell script into the image that runs before every execution — use it for git config, SSH keys, tool setup, or anything your agent needs before it starts coding.
+
+### Config approach (recommended for servers)
+
+Define `prebuiltImages` in `isol8.config.json` so images are built automatically when the server starts or when you run `isol8 setup`:
+
+```json
+{
+  "$schema": "https://raw.githubusercontent.com/Illusion47586/isol8/main/packages/core/schema/isol8.config.schema.json",
+  "maxConcurrent": 20,
+  "prebuiltImages": [
+    {
+      "tag": "my-org/python-devbox:latest",
+      "runtime": "python",
+      "installPackages": ["numpy", "pandas", "scikit-learn", "pytest", "black", "ruff"],
+      "setupScript": "git config --global user.name 'agent' && git config --global user.email 'agent@ci'"
+    },
+    {
+      "tag": "my-org/node-devbox:latest",
+      "runtime": "node",
+      "installPackages": ["typescript", "eslint", "prettier", "jest"]
+    }
+  ],
+  "defaults": {
+    "timeoutMs": 300000,
+    "memoryLimit": "2g",
+    "network": "filtered"
+  },
+  "network": {
+    "whitelist": ["^github\\.com$", "^api\\.github\\.com$", "^registry\\.npmjs\\.org$", "^pypi\\.org$"],
+    "blacklist": ["^169\\.254\\."]
+  },
+  "cleanup": {
+    "autoPrune": true,
+    "maxContainerAgeMs": 7200000
+  },
+  "poolStrategy": "fast",
+  "poolSize": { "clean": 5, "dirty": 5 }
+}
+```
+
+Then build everything:
+
+```bash
+isol8 setup
+```
+
+<Tip>
+  isol8 uses content-addressed hashing for custom images. If the packages and setup script haven't changed, `isol8 setup` skips the build entirely — making it safe to call on every deploy.
+</Tip>
+
+## Step 2: Create the orchestrator
+
+The orchestrator is the "blueprint" — a TypeScript program that sequences deterministic steps and agentic LLM steps. Use `DockerIsol8` in persistent mode with your custom image.
+
+```typescript
+import { DockerIsol8 } from "@isol8/core";
+import type { ExecutionResult } from "@isol8/core";
+
+const engine = new DockerIsol8({
+  mode: "persistent",
+  image: "my-org/python-devbox:latest",
+  network: "filtered",
+  networkFilter: {
+    whitelist: ["^github\\.com$", "^api\\.github\\.com$", "^pypi\\.org$"],
+    blacklist: ["^169\\.254\\."],
+  },
+  timeoutMs: 300_000, // 5 minutes per step
+  memoryLimit: "2g",
+  secrets: {
+    GITHUB_TOKEN: process.env.GITHUB_TOKEN!,
+  },
+});
+
+await engine.start();
+```
+
+<Note>
+  `mode: "persistent"` reuses a single container across all `execute()` calls, preserving filesystem state — just like Stripe's devboxes persist across agent steps.
+</Note>
+
+## Step 3: Hydrate context (clone repo, inject rules)
+
+Before the agent starts coding, set up the workspace. This is the equivalent of Stripe's devbox warm-up and their deterministic "context gathering" nodes.
+
+```typescript
+// Clone the repository into the persistent container
+const cloneResult = await engine.execute({
+  runtime: "bash",
+  code: `
+    cd /sandbox
+    git clone https://$GITHUB_TOKEN@github.com/my-org/my-repo.git repo
+    cd repo
+    git checkout -b agent/fix-issue-42 origin/main
+  `,
+});
+
+if (cloneResult.exitCode !== 0) {
+  throw new Error(`Clone failed: ${cloneResult.stderr}`);
+}
+
+// Inject agent rules and task context as files
+await engine.putFile("/sandbox/repo/AGENT_CONTEXT.md", `
+# Task
+Fix the type error in src/utils/parser.ts described in issue #42.
+
+# Rules
+- Follow existing code style (prettier + eslint enforced)
+- Write tests for any new functions
+- Do not modify the public API surface
+- Commit messages should reference the issue number
+`);
+```
+
+You can also inject rule files, `.cursorrules`, `CLAUDE.md`, or any context documents your agent needs:
+
+```typescript
+// Inject project-specific agent rules from your repo
+const rulesContent = await fs.readFile("./agent-rules/python-rules.md", "utf-8");
+await engine.putFile("/sandbox/repo/.agent-rules.md", rulesContent);
+```
+
+## Step 4: Implement the agent loop
+
+This is the agentic step — call your LLM to generate code, then execute it inside isol8. The LLM writes code; isol8 runs it in isolation.
+
+```typescript
+import Anthropic from "@anthropic-ai/sdk";
+
+const anthropic = new Anthropic();
+
+async function agentImplement(task: string): Promise<void> {
+  const MAX_ITERATIONS = 10;
+
+  // Read the current repo state
+  const repoState = await engine.execute({
+    runtime: "bash",
+    code: "cd /sandbox/repo && find src -name '*.ts' | head -50 && echo '---' && cat src/utils/parser.ts",
+  });
+
+  let messages: Anthropic.MessageParam[] = [
+    {
+      role: "user",
+      content: `You are a coding agent working in /sandbox/repo. Here is the current state:\n\n${repoState.stdout}\n\nTask: ${task}\n\nWrite a bash script that makes the necessary code changes. Use heredocs or sed for file edits. Output only the bash script, no explanation.`,
+    },
+  ];
+
+  for (let i = 0; i < MAX_ITERATIONS; i++) {
+    const response = await anthropic.messages.create({
+      model: "claude-sonnet-4-20250514",
+      max_tokens: 4096,
+      system: "You are a precise coding agent. Write bash scripts to modify code. Always verify your changes compile/pass lint before declaring done. Respond ONLY with a bash script, or the word DONE if the task is complete.",
+      messages,
+    });
+
+    const text = response.content[0].type === "text" ? response.content[0].text : "";
+
+    if (text.trim() === "DONE") {
+      console.log(`Agent completed in ${i + 1} iterations`);
+      return;
+    }
+
+    // Execute the agent's code in the sandbox
+    const result = await engine.execute({
+      runtime: "bash",
+      code: text,
+      workdir: "/sandbox/repo",
+    });
+
+    // Feed the result back to the agent
+    messages.push(
+      { role: "assistant", content: text },
+      {
+        role: "user",
+        content: `Exit code: ${result.exitCode}\nStdout:\n${result.stdout}\nStderr:\n${result.stderr}\n\nContinue implementing, or respond DONE if the task is complete.`,
+      }
+    );
+  }
+
+  throw new Error("Agent did not complete within iteration limit");
+}
+```
+
+<Warning>
+  The agent's code runs as user `sandbox` (uid 100) with a read-only root filesystem. Only `/sandbox` (the tmpfs work area) is writable. This prevents the agent from escaping its sandbox, even if the LLM generates malicious code.
+</Warning>
+
+## Step 5: Deterministic lint and test steps
+
+After the agent finishes coding, run linters and tests deterministically — no LLM involvement. This matches Stripe's blueprint pattern of interleaving deterministic nodes with agentic nodes.
+
+```typescript
+async function runLint(): Promise<ExecutionResult> {
+  return engine.execute({
+    runtime: "bash",
+    code: `
+      cd /sandbox/repo
+      npx prettier --write 'src/**/*.ts'
+      npx eslint --fix 'src/**/*.ts'
+      echo "Lint complete"
+    `,
+    workdir: "/sandbox/repo",
+    timeoutMs: 60_000,
+  });
+}
+
+async function runTests(): Promise<ExecutionResult> {
+  return engine.execute({
+    runtime: "bash",
+    code: `
+      cd /sandbox/repo
+      npx jest --ci --passWithNoTests 2>&1
+    `,
+    workdir: "/sandbox/repo",
+    timeoutMs: 120_000,
+  });
+}
+```
+
+## Step 6: Wire up the full blueprint
+
+Combine all steps into a single orchestration flow, mirroring Stripe's blueprint pattern of at most two CI rounds:
+
+```typescript
+async function runMinion(task: string) {
+  const MAX_CI_ROUNDS = 2;
+
+  // --- Deterministic: setup ---
+  console.log("[1/5] Cloning repo and hydrating context...");
+  await cloneAndSetup();
+
+  // --- Agentic: implement ---
+  console.log("[2/5] Agent implementing task...");
+  await agentImplement(task);
+
+  // --- Deterministic: lint ---
+  console.log("[3/5] Running linters...");
+  const lintResult = await runLint();
+  if (lintResult.exitCode !== 0) {
+    // Let the agent fix lint issues
+    await agentImplement("Fix the lint errors: " + lintResult.stderr);
+    await runLint(); // Re-run lint after agent fix
+  }
+
+  // --- Deterministic: test + iterate ---
+  for (let round = 1; round <= MAX_CI_ROUNDS; round++) {
+    console.log(`[4/5] Running tests (round ${round}/${MAX_CI_ROUNDS})...`);
+    const testResult = await runTests();
+
+    if (testResult.exitCode === 0) {
+      console.log("Tests passed!");
+      break;
+    }
+
+    if (round < MAX_CI_ROUNDS) {
+      // --- Agentic: fix failures ---
+      console.log("Tests failed, agent fixing...");
+      await agentImplement(
+        "Fix the failing tests. Errors:\n" + testResult.stderr
+      );
+    } else {
+      console.log("Tests still failing after max rounds. Proceeding with PR for human review.");
+    }
+  }
+
+  // --- Deterministic: commit and push ---
+  console.log("[5/5] Committing and pushing...");
+  await engine.execute({
+    runtime: "bash",
+    code: `
+      cd /sandbox/repo
+      git add -A
+      git commit -m "fix: resolve type error in parser (closes #42)
+
+      Automated change produced by coding agent."
+      git push origin agent/fix-issue-42
+    `,
+    workdir: "/sandbox/repo",
+  });
+
+  // --- Deterministic: create PR ---
+  await engine.execute({
+    runtime: "bash",
+    code: `
+      cd /sandbox/repo
+      gh pr create \
+        --title "fix: resolve type error in parser (closes #42)" \
+        --body "## Summary
+      Automated fix for issue #42.
+
+      This PR was produced by an unattended coding agent. Please review carefully.
+
+      ## Changes
+      - Fixed type error in src/utils/parser.ts
+      - Added unit tests" \
+        --base main \
+        --head agent/fix-issue-42
+    `,
+    workdir: "/sandbox/repo",
+  });
+
+  await engine.stop();
+  console.log("Done! PR created for human review.");
+}
+
+// Run it
+runMinion("Fix the type error in src/utils/parser.ts described in issue #42");
+```
+
+## Scaling with the remote server
+
+For production, run isol8 as a centralized server so multiple agents can execute in parallel — the equivalent of Stripe's fleet of devboxes. Each agent gets its own persistent session.
+
+### Start the server
+
+```bash
+isol8 serve --port 3000 --key "$ISOL8_API_KEY"
+```
+
+### Connect agents via RemoteIsol8
+
+```typescript
+import { RemoteIsol8 } from "@isol8/core";
+import { randomUUID } from "node:crypto";
+
+async function spawnAgent(task: string) {
+  const sessionId = `agent-${randomUUID()}`;
+
+  const engine = new RemoteIsol8(
+    {
+      host: "http://isol8-server.internal:3000",
+      apiKey: process.env.ISOL8_API_KEY!,
+      sessionId,
+    },
+    {
+      image: "my-org/python-devbox:latest",
+      network: "filtered",
+      networkFilter: {
+        whitelist: ["^github\\.com$", "^api\\.github\\.com$"],
+        blacklist: [],
+      },
+      timeoutMs: 300_000,
+      memoryLimit: "2g",
+    }
+  );
+
+  await engine.start();
+
+  // Run the full agent blueprint against the remote session
+  // Each session is an isolated persistent container
+  await runBlueprintAgainst(engine, task);
+
+  await engine.stop(); // Cleans up the remote session
+}
+
+// Spawn multiple agents in parallel
+await Promise.all([
+  spawnAgent("Fix issue #42"),
+  spawnAgent("Fix issue #43"),
+  spawnAgent("Add unit tests for auth module"),
+]);
+```
+
+### Stream agent output in real-time
+
+Use streaming to pipe agent activity to a UI or Slack thread:
+
+```typescript
+for await (const event of engine.executeStream({
+  runtime: "bash",
+  code: "cd /sandbox/repo && npm test 2>&1",
+})) {
+  switch (event.type) {
+    case "stdout":
+      slackThread.postUpdate(event.data);
+      break;
+    case "stderr":
+      slackThread.postWarning(event.data);
+      break;
+    case "exit":
+      slackThread.postResult(`Tests finished with exit code ${event.data}`);
+      break;
+  }
+}
+```
+
+## Stripe Minions concept mapping
+
+| Stripe Minions concept | isol8 equivalent |
+|:--|:--|
+| Devbox (pre-warmed EC2 instance) | Custom image with `prebuiltImages` + persistent session |
+| Devbox pool (hot and ready) | Warm container pool (`poolSize`, `poolStrategy: "fast"`) |
+| Isolated environment (no production access) | `network: "filtered"` with allowlisted hosts |
+| Blueprint (deterministic + agentic nodes) | Orchestrator code mixing `engine.execute()` with LLM calls |
+| Rule files (Cursor rules, CLAUDE.md) | Files injected via `putFile()` or `files` in `ExecutionRequest` |
+| MCP tools (Toolshed) | `network: "filtered"` allowing agent to call external APIs |
+| Local lint loop (pre-push hooks) | Deterministic lint step with `engine.execute()` before push |
+| CI feedback loop (at most 2 rounds) | Test step looped with `MAX_CI_ROUNDS` + agentic fix step |
+| Secret isolation (no prod credentials) | `secrets` option with automatic output masking |
+| Parallelization (many devboxes) | Multiple `RemoteIsol8` sessions via centralized server |
+
+## Security considerations
+
+Stripe isolates their devboxes from production. isol8 provides equivalent guardrails:
+
+- **Read-only root filesystem** — agents can only write to `/sandbox` and `/tmp`
+- **Non-root execution** — all code runs as `sandbox` user (uid 100)
+- **Network filtering** — allowlist only the hosts your agent needs (GitHub, package registries)
+- **Secret masking** — credentials passed via `secrets` are automatically redacted from stdout/stderr
+- **Resource limits** — CPU, memory, PIDs, and output size caps prevent runaway agents
+- **Seccomp profiles** — strict syscall filtering by default
+- **Session isolation** — each agent session is a separate container with no shared state
+
+```typescript
+const engine = new DockerIsol8({
+  mode: "persistent",
+  image: "my-org/node-devbox:latest",
+  network: "filtered",
+  networkFilter: {
+    whitelist: ["^github\\.com$", "^registry\\.npmjs\\.org$"],
+    blacklist: ["^169\\.254\\.", "^10\\.", "^172\\.(1[6-9]|2[0-9]|3[01])\\."],
+  },
+  secrets: {
+    GITHUB_TOKEN: process.env.GITHUB_TOKEN!,
+    NPM_TOKEN: process.env.NPM_TOKEN!,
+  },
+  cpuLimit: 2,
+  memoryLimit: "2g",
+  pidsLimit: 128,
+  maxOutputSize: 5_242_880, // 5MB
+  security: {
+    seccomp: "strict",
+  },
+});
+```
+
+## Tips from the Stripe playbook
+
+1. **Shift feedback left** — run linters and fast checks inside the container before pushing to CI. This saves tokens and compute.
+2. **Limit CI rounds** — diminishing returns after 1-2 rounds. Cap iterations and hand off to humans.
+3. **Bake dependencies into images** — don't waste agent time installing packages. Use `prebuiltImages` to pre-install everything.
+4. **Scope context tightly** — don't dump your entire codebase into the agent's context window. Inject only relevant rule files and documentation.
+5. **Deterministic where possible** — lint, format, test, commit, and push are deterministic steps. Don't let the LLM do what a shell script can do better.
+6. **Isolate by default** — use `network: "none"` or `network: "filtered"` as your baseline. Only open the network for hosts the agent genuinely needs.
+7. **Use setup scripts** — bake recurring setup (git config, SSH, tool configuration) into the custom image's `setupScript` so it runs automatically.
+
+## Related pages
+
+<CardGroup cols={2}>
+  <Card title="AI agent code execution" icon="robot" href="/guides/ai-agents">
+    Foundational patterns for LLM tool-call loops with isol8.
+  </Card>
+  <Card title="Data and persistence" icon="database" href="/persistence">
+    Persistent sessions, file I/O, and state management across runs.
+  </Card>
+  <Card title="Security model" icon="shield-check" href="/security">
+    Network controls, seccomp, secret masking, and isolation boundaries.
+  </Card>
+  <Card title="Remote server" icon="server" href="/remote">
+    Deploy isol8 as a centralized execution server for agent fleets.
+  </Card>
+</CardGroup>

--- a/apps/docs/guides/one-shot-coding-agents.mdx
+++ b/apps/docs/guides/one-shot-coding-agents.mdx
@@ -12,7 +12,7 @@ The architecture behind Minions has three pillars:
 2. **A blueprint-driven agent loop** — deterministic steps (lint, test, push) interleaved with agentic LLM steps (implement, fix failures).
 3. **Context hydration** — rule files, MCP tools, and documentation injected before the agent starts.
 
-isol8 gives you pillar 1 out of the box, and the building blocks to wire up pillars 2 and 3. This guide walks through the full setup using **custom images** as your pre-warmed devboxes.
+isol8 gives you pillar 1 out of the box, and the building blocks to wire up pillars 2 and 3. This guide walks through the full setup using **custom images** as your pre-warmed devboxes and the **`agent` runtime** as your agentic step.
 
 ## Architecture overview
 
@@ -23,12 +23,12 @@ flowchart TD
   B --> C["Build / select custom image"]
   C --> D["isol8 persistent session"]
   D --> E["Setup: clone repo, hydrate context"]
-  E --> F["Agent loop: implement task"]
+  E --> F["Agent step: runtime='agent', code=prompt"]
   F --> G{{"Lint locally"}}
   G -->|Fail| F
   G -->|Pass| H["Push + run CI"]
   H --> I{{"CI passes?"}}
-  I -->|Fail round 1| J["Agent loop: fix CI failures"]
+  I -->|Fail round 1| J["Agent step: fix CI failures"]
   J --> H
   I -->|Pass or round 2| K["Create PR for human review"]
 ```
@@ -107,7 +107,7 @@ isol8 setup
 
 ## Step 2: Create the orchestrator
 
-The orchestrator is the "blueprint" — a TypeScript program that sequences deterministic steps and agentic LLM steps. Use `DockerIsol8` in persistent mode with your custom image.
+The orchestrator is the "blueprint" — a TypeScript program that sequences deterministic bash steps and agentic `agent` runtime steps. Use `DockerIsol8` in persistent mode with your custom image.
 
 ```typescript
 import { DockerIsol8 } from "@isol8/core";
@@ -118,13 +118,16 @@ const engine = new DockerIsol8({
   image: "my-org/python-devbox:latest",
   network: "filtered",
   networkFilter: {
-    whitelist: ["^github\\.com$", "^api\\.github\\.com$", "^pypi\\.org$"],
+    // Allow LLM API access + package registries
+    whitelist: ["^api\\.anthropic\\.com$", "^github\\.com$", "^api\\.github\\.com$", "^pypi\\.org$"],
     blacklist: ["^169\\.254\\."],
   },
   timeoutMs: 300_000, // 5 minutes per step
   memoryLimit: "2g",
+  pidsLimit: 200,     // agent runtime spawns subprocesses
   secrets: {
     GITHUB_TOKEN: process.env.GITHUB_TOKEN!,
+    ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY!,
   },
 });
 
@@ -168,77 +171,53 @@ Fix the type error in src/utils/parser.ts described in issue #42.
 `);
 ```
 
-You can also inject rule files, `.cursorrules`, `CLAUDE.md`, or any context documents your agent needs:
+You can also inject rule files, `.cursorrules`, `AGENTS.md`, or any context documents your agent needs:
 
 ```typescript
 // Inject project-specific agent rules from your repo
 const rulesContent = await fs.readFile("./agent-rules/python-rules.md", "utf-8");
-await engine.putFile("/sandbox/repo/.agent-rules.md", rulesContent);
+await engine.putFile("/sandbox/repo/AGENTS.md", rulesContent);
 ```
 
-## Step 4: Implement the agent loop
+<Note>
+  pi automatically loads `AGENTS.md` (and `CLAUDE.md`) from the working directory at startup. Injecting your rules as `/sandbox/repo/AGENTS.md` is the recommended way to supply project context.
+</Note>
 
-This is the agentic step — call your LLM to generate code, then execute it inside isol8. The LLM writes code; isol8 runs it in isolation.
+## Step 4: Run the agent step
+
+This is the agentic step — use `runtime: "agent"` to run the pi coding agent inside the sandbox. The `code` field is the prompt; pi handles the LLM loop, tool calls, and file edits autonomously.
 
 ```typescript
-import Anthropic from "@anthropic-ai/sdk";
-
-const anthropic = new Anthropic();
-
-async function agentImplement(task: string): Promise<void> {
-  const MAX_ITERATIONS = 10;
-
-  // Read the current repo state
-  const repoState = await engine.execute({
-    runtime: "bash",
-    code: "cd /sandbox/repo && find src -name '*.ts' | head -50 && echo '---' && cat src/utils/parser.ts",
-  });
-
-  let messages: Anthropic.MessageParam[] = [
-    {
-      role: "user",
-      content: `You are a coding agent working in /sandbox/repo. Here is the current state:\n\n${repoState.stdout}\n\nTask: ${task}\n\nWrite a bash script that makes the necessary code changes. Use heredocs or sed for file edits. Output only the bash script, no explanation.`,
+async function agentImplement(task: string): Promise<ExecutionResult> {
+  return engine.execute({
+    runtime: "agent",
+    code: task,
+    agentFlags: "--model anthropic/claude-sonnet-4-5 --thinking low",
+    timeoutMs: 300_000,
+    env: {
+      // pi reads the LLM API key from the environment
+      ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY!,
     },
-  ];
-
-  for (let i = 0; i < MAX_ITERATIONS; i++) {
-    const response = await anthropic.messages.create({
-      model: "claude-sonnet-4-20250514",
-      max_tokens: 4096,
-      system: "You are a precise coding agent. Write bash scripts to modify code. Always verify your changes compile/pass lint before declaring done. Respond ONLY with a bash script, or the word DONE if the task is complete.",
-      messages,
-    });
-
-    const text = response.content[0].type === "text" ? response.content[0].text : "";
-
-    if (text.trim() === "DONE") {
-      console.log(`Agent completed in ${i + 1} iterations`);
-      return;
-    }
-
-    // Execute the agent's code in the sandbox
-    const result = await engine.execute({
-      runtime: "bash",
-      code: text,
-      workdir: "/sandbox/repo",
-    });
-
-    // Feed the result back to the agent
-    messages.push(
-      { role: "assistant", content: text },
-      {
-        role: "user",
-        content: `Exit code: ${result.exitCode}\nStdout:\n${result.stdout}\nStderr:\n${result.stderr}\n\nContinue implementing, or respond DONE if the task is complete.`,
-      }
-    );
-  }
-
-  throw new Error("Agent did not complete within iteration limit");
+  });
 }
 ```
 
+<Tip>
+  The agent runtime automatically appends a system prompt informing pi that it is running inside an isol8 sandbox with restricted network access and an ephemeral filesystem. You do not need to add this yourself.
+</Tip>
+
+The `agentFlags` field passes arguments directly to the `pi` CLI before `-p`. Useful flags:
+
+| Flag | Description |
+|:---|:---|
+| `--model <provider/id>` | LLM to use (e.g. `anthropic/claude-sonnet-4-5`, `openai/gpt-4o`) |
+| `--thinking <level>` | Thinking budget: `off`, `minimal`, `low`, `medium`, `high`, `xhigh` |
+| `--no-skills` | Disable auto-loading of skill files |
+| `--no-extensions` | Disable auto-loading of extensions |
+| `--tools <list>` | Limit built-in tools (default: `read,bash,edit,write`) |
+
 <Warning>
-  The agent's code runs as user `sandbox` (uid 100) with a read-only root filesystem. Only `/sandbox` (the tmpfs work area) is writable. This prevents the agent from escaping its sandbox, even if the LLM generates malicious code.
+  The agent runtime enforces `network: "filtered"` — it will throw if you pass `network: "none"` or `network: "host"`. The whitelist must include at least one LLM API endpoint (e.g. `^api\\.anthropic\\.com$`).
 </Warning>
 
 ## Step 5: Deterministic lint and test steps
@@ -255,7 +234,6 @@ async function runLint(): Promise<ExecutionResult> {
       npx eslint --fix 'src/**/*.ts'
       echo "Lint complete"
     `,
-    workdir: "/sandbox/repo",
     timeoutMs: 60_000,
   });
 }
@@ -267,7 +245,6 @@ async function runTests(): Promise<ExecutionResult> {
       cd /sandbox/repo
       npx jest --ci --passWithNoTests 2>&1
     `,
-    workdir: "/sandbox/repo",
     timeoutMs: 120_000,
   });
 }
@@ -285,17 +262,20 @@ async function runMinion(task: string) {
   console.log("[1/5] Cloning repo and hydrating context...");
   await cloneAndSetup();
 
-  // --- Agentic: implement ---
+  // --- Agentic: implement (runtime: "agent") ---
   console.log("[2/5] Agent implementing task...");
-  await agentImplement(task);
+  const implResult = await agentImplement(task);
+  if (implResult.exitCode !== 0) {
+    console.warn("Agent step exited non-zero:", implResult.stderr);
+  }
 
   // --- Deterministic: lint ---
   console.log("[3/5] Running linters...");
   const lintResult = await runLint();
   if (lintResult.exitCode !== 0) {
     // Let the agent fix lint issues
-    await agentImplement("Fix the lint errors: " + lintResult.stderr);
-    await runLint(); // Re-run lint after agent fix
+    await agentImplement("Fix the lint errors:\n" + lintResult.stderr);
+    await runLint();
   }
 
   // --- Deterministic: test + iterate ---
@@ -311,9 +291,7 @@ async function runMinion(task: string) {
     if (round < MAX_CI_ROUNDS) {
       // --- Agentic: fix failures ---
       console.log("Tests failed, agent fixing...");
-      await agentImplement(
-        "Fix the failing tests. Errors:\n" + testResult.stderr
-      );
+      await agentImplement("Fix the failing tests. Errors:\n" + testResult.stderr);
     } else {
       console.log("Tests still failing after max rounds. Proceeding with PR for human review.");
     }
@@ -331,7 +309,6 @@ async function runMinion(task: string) {
       Automated change produced by coding agent."
       git push origin agent/fix-issue-42
     `,
-    workdir: "/sandbox/repo",
   });
 
   // --- Deterministic: create PR ---
@@ -352,7 +329,6 @@ async function runMinion(task: string) {
         --base main \
         --head agent/fix-issue-42
     `,
-    workdir: "/sandbox/repo",
   });
 
   await engine.stop();
@@ -392,21 +368,21 @@ async function spawnAgent(task: string) {
       image: "my-org/python-devbox:latest",
       network: "filtered",
       networkFilter: {
-        whitelist: ["^github\\.com$", "^api\\.github\\.com$"],
+        whitelist: ["^api\\.anthropic\\.com$", "^github\\.com$", "^api\\.github\\.com$"],
         blacklist: [],
       },
       timeoutMs: 300_000,
       memoryLimit: "2g",
+      pidsLimit: 200,
     }
   );
 
   await engine.start();
 
   // Run the full agent blueprint against the remote session
-  // Each session is an isolated persistent container
   await runBlueprintAgainst(engine, task);
 
-  await engine.stop(); // Cleans up the remote session
+  await engine.stop();
 }
 
 // Spawn multiple agents in parallel
@@ -423,8 +399,9 @@ Use streaming to pipe agent activity to a UI or Slack thread:
 
 ```typescript
 for await (const event of engine.executeStream({
-  runtime: "bash",
-  code: "cd /sandbox/repo && npm test 2>&1",
+  runtime: "agent",
+  code: "Fix the type error in src/utils/parser.ts",
+  agentFlags: "--model anthropic/claude-sonnet-4-5",
 })) {
   switch (event.type) {
     case "stdout":
@@ -434,7 +411,7 @@ for await (const event of engine.executeStream({
       slackThread.postWarning(event.data);
       break;
     case "exit":
-      slackThread.postResult(`Tests finished with exit code ${event.data}`);
+      slackThread.postResult(`Agent finished with exit code ${event.data}`);
       break;
   }
 }
@@ -447,11 +424,12 @@ for await (const event of engine.executeStream({
 | Devbox (pre-warmed EC2 instance) | Custom image with `prebuiltImages` + persistent session |
 | Devbox pool (hot and ready) | Warm container pool (`poolSize`, `poolStrategy: "fast"`) |
 | Isolated environment (no production access) | `network: "filtered"` with allowlisted hosts |
-| Blueprint (deterministic + agentic nodes) | Orchestrator code mixing `engine.execute()` with LLM calls |
-| Rule files (Cursor rules, CLAUDE.md) | Files injected via `putFile()` or `files` in `ExecutionRequest` |
+| Blueprint (deterministic + agentic nodes) | Orchestrator mixing `runtime: "bash"` steps with `runtime: "agent"` steps |
+| Agentic node (LLM implements/fixes) | `engine.execute({ runtime: "agent", code: prompt, agentFlags: ... })` |
+| Rule files (Cursor rules, AGENTS.md) | Files injected via `putFile()` — pi auto-loads `AGENTS.md` from cwd |
 | MCP tools (Toolshed) | `network: "filtered"` allowing agent to call external APIs |
-| Local lint loop (pre-push hooks) | Deterministic lint step with `engine.execute()` before push |
-| CI feedback loop (at most 2 rounds) | Test step looped with `MAX_CI_ROUNDS` + agentic fix step |
+| Local lint loop (pre-push hooks) | Deterministic lint step with `runtime: "bash"` before push |
+| CI feedback loop (at most 2 rounds) | Test step looped with `MAX_CI_ROUNDS` + agent fix step |
 | Secret isolation (no prod credentials) | `secrets` option with automatic output masking |
 | Parallelization (many devboxes) | Multiple `RemoteIsol8` sessions via centralized server |
 
@@ -461,11 +439,12 @@ Stripe isolates their devboxes from production. isol8 provides equivalent guardr
 
 - **Read-only root filesystem** — agents can only write to `/sandbox` and `/tmp`
 - **Non-root execution** — all code runs as `sandbox` user (uid 100)
-- **Network filtering** — allowlist only the hosts your agent needs (GitHub, package registries)
+- **Network filtering** — allowlist only the hosts your agent needs (LLM APIs, GitHub, package registries)
 - **Secret masking** — credentials passed via `secrets` are automatically redacted from stdout/stderr
 - **Resource limits** — CPU, memory, PIDs, and output size caps prevent runaway agents
 - **Seccomp profiles** — strict syscall filtering by default
 - **Session isolation** — each agent session is a separate container with no shared state
+- **Sandbox-aware system prompt** — isol8 automatically injects a system prompt informing pi of the sandbox constraints, so the agent doesn't attempt operations that will fail
 
 ```typescript
 const engine = new DockerIsol8({
@@ -473,20 +452,17 @@ const engine = new DockerIsol8({
   image: "my-org/node-devbox:latest",
   network: "filtered",
   networkFilter: {
-    whitelist: ["^github\\.com$", "^registry\\.npmjs\\.org$"],
+    whitelist: ["^api\\.anthropic\\.com$", "^github\\.com$", "^registry\\.npmjs\\.org$"],
     blacklist: ["^169\\.254\\.", "^10\\.", "^172\\.(1[6-9]|2[0-9]|3[01])\\."],
   },
   secrets: {
     GITHUB_TOKEN: process.env.GITHUB_TOKEN!,
-    NPM_TOKEN: process.env.NPM_TOKEN!,
+    ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY!,
   },
   cpuLimit: 2,
   memoryLimit: "2g",
-  pidsLimit: 128,
+  pidsLimit: 200,
   maxOutputSize: 5_242_880, // 5MB
-  security: {
-    seccomp: "strict",
-  },
 });
 ```
 
@@ -495,19 +471,19 @@ const engine = new DockerIsol8({
 1. **Shift feedback left** — run linters and fast checks inside the container before pushing to CI. This saves tokens and compute.
 2. **Limit CI rounds** — diminishing returns after 1-2 rounds. Cap iterations and hand off to humans.
 3. **Bake dependencies into images** — don't waste agent time installing packages. Use `prebuiltImages` to pre-install everything.
-4. **Scope context tightly** — don't dump your entire codebase into the agent's context window. Inject only relevant rule files and documentation.
+4. **Scope context tightly** — inject only relevant rule files and documentation as `AGENTS.md`. Don't dump your entire codebase.
 5. **Deterministic where possible** — lint, format, test, commit, and push are deterministic steps. Don't let the LLM do what a shell script can do better.
-6. **Isolate by default** — use `network: "none"` or `network: "filtered"` as your baseline. Only open the network for hosts the agent genuinely needs.
-7. **Use setup scripts** — bake recurring setup (git config, SSH, tool configuration) into the custom image's `setupScript` so it runs automatically.
+6. **Isolate by default** — the agent runtime requires `network: "filtered"`. Whitelist only what the agent genuinely needs.
+7. **Use setup scripts** — bake recurring setup (git config, SSH, tool configuration) into the custom image's `setupScript` so it runs automatically before the agent starts.
 
 ## Related pages
 
 <CardGroup cols={2}>
+  <Card title="Agent in a Box" icon="microchip-ai" href="/agent-in-a-box">
+    Full reference for the agent runtime: flags, networking, file injection, and streaming.
+  </Card>
   <Card title="AI agent code execution" icon="robot" href="/guides/ai-agents">
     Foundational patterns for LLM tool-call loops with isol8.
-  </Card>
-  <Card title="Data and persistence" icon="database" href="/persistence">
-    Persistent sessions, file I/O, and state management across runs.
   </Card>
   <Card title="Security model" icon="shield-check" href="/security">
     Network controls, seccomp, secret masking, and isolation boundaries.

--- a/apps/docs/index.mdx
+++ b/apps/docs/index.mdx
@@ -38,8 +38,11 @@ isol8 is built around three priorities that matter in real usage:
 ## Core features
 
 <CardGroup cols={2}>
+  <Card title="Agent in a Box" icon="microchip-ai" href="/agent-in-a-box">
+    Run a full coding agent (pi) inside an isol8 sandbox. Give an LLM a filesystem, tools, and controlled network access in a single `execute()` call.
+  </Card>
   <Card title="Multi-runtime isolation" icon="box" href="/runtimes">
-    Execute Python, Node.js, Bun, Deno, Bash, and AI agent code inside isolated Docker sandboxes.
+    Execute Python, Node.js, Bun, Deno, and Bash inside isolated Docker sandboxes.
   </Card>
   <Card title="Execution modes" icon="repeat" href="/persistence">
     Use ephemeral runs for clean isolation or persistent sessions when you need stateful workflows.

--- a/apps/docs/index.mdx
+++ b/apps/docs/index.mdx
@@ -39,7 +39,7 @@ isol8 is built around three priorities that matter in real usage:
 
 <CardGroup cols={2}>
   <Card title="Multi-runtime isolation" icon="box" href="/runtimes">
-    Execute Python, Node.js, Bun, Deno, and Bash code inside isolated Docker sandboxes.
+    Execute Python, Node.js, Bun, Deno, Bash, and AI agent code inside isolated Docker sandboxes.
   </Card>
   <Card title="Execution modes" icon="repeat" href="/persistence">
     Use ephemeral runs for clean isolation or persistent sessions when you need stateful workflows.

--- a/apps/docs/option-mapping.mdx
+++ b/apps/docs/option-mapping.mdx
@@ -125,8 +125,8 @@ Use this reference when you need to answer: "where should I set this value?"
   **Library**: `execute({ allowInsecureCodeUrl: true })`.
 </ResponseField>
 
-<ResponseField name="runtime" type="'python' | 'node' | 'bun' | 'deno' | 'bash'">
-  **CLI**: `-r, --runtime` or extension auto-detection.
+<ResponseField name="runtime" type="'python' | 'node' | 'bun' | 'deno' | 'bash' | 'agent'">
+  **CLI**: `-r, --runtime` or extension auto-detection. The `agent` runtime must be specified explicitly.
 
   **Config**: not set via config.
 
@@ -172,7 +172,7 @@ Use this reference when you need to answer: "where should I set this value?"
 </ResponseField>
 
 <ResponseField name="files" type="Record<string, string | Buffer>">
-  **CLI**: not exposed as a `run` flag.
+  **CLI**: `--files <dir>` (recursively injects a directory into `/sandbox`, primarily for agent runtime).
 
   **API**: `request.files`.
 
@@ -215,6 +215,16 @@ Use this reference when you need to answer: "where should I set this value?"
   **API**: `request.workdir`.
 
   **Library**: `execute({ workdir })`.
+</ResponseField>
+
+<ResponseField name="agentFlags" type="string">
+  Extra flags passed to the `pi` coding agent (e.g. `--model claude-sonnet-4-20250514 --thinking`). Only used when `runtime` is `"agent"`.
+
+  **CLI**: `--agent-flags <flags>`.
+
+  **API**: `request.agentFlags`.
+
+  **Library**: `execute({ agentFlags })`.
 </ResponseField>
 
 <ResponseField name="metadata" type="Record<string, string>">

--- a/apps/docs/runtimes.mdx
+++ b/apps/docs/runtimes.mdx
@@ -1,10 +1,10 @@
 ---
 title: "Runtime reference"
-description: "Supported runtimes, extension mapping, module behavior, and package-install semantics for Python, Node, Bun, Deno, and Bash."
+description: "Supported runtimes, extension mapping, module behavior, and package-install semantics for Python, Node, Bun, Deno, Bash, and Agent."
 icon: "layer-group"
 ---
 
-isol8 supports five runtimes with a shared execution contract (`ExecutionRequest.runtime`) and runtime-specific command/extension behavior.
+isol8 supports six runtimes with a shared execution contract (`ExecutionRequest.runtime`) and runtime-specific command/extension behavior.
 
 ## Supported runtimes
 
@@ -15,9 +15,10 @@ isol8 supports five runtimes with a shared execution contract (`ExecutionRequest
 | Bun | `isol8:bun` | `.ts` | none | Yes |
 | Deno | `isol8:deno` | `.mts` | none | Yes (engine writes temp file) |
 | Bash | `isol8:bash` | `.sh` | none | Yes |
+| Agent | `isol8:agent` | none | none | Yes (prompt text via `-e`) |
 
 <Note>
-  Registration order matters for extension detection: Bun wins `.ts`; Deno uses `.mts` to avoid collision.
+  Registration order matters for extension detection: Bun wins `.ts`; Deno uses `.mts` to avoid collision. The Agent runtime has no extension mapping and must always be specified explicitly via `--runtime agent`.
 </Note>
 
 ## How runtime selection works
@@ -33,6 +34,11 @@ isol8 supports five runtimes with a shared execution contract (`ExecutionRequest
 
     # Explicit override
     isol8 run script.any --runtime python
+
+    # Agent (always explicit, prompt as -e)
+    isol8 run -e "add tests for all endpoints" --runtime agent \
+      --net filtered --allow "api.anthropic.com" \
+      --secret "ANTHROPIC_API_KEY=sk-..."
     ```
   </Tab>
   <Tab title="Library">
@@ -40,6 +46,12 @@ isol8 supports five runtimes with a shared execution contract (`ExecutionRequest
     await engine.execute({
       runtime: "python",
       code: "print('hello')",
+    });
+
+    // Agent runtime (code = prompt text)
+    await engine.execute({
+      runtime: "agent",
+      code: "refactor this module to use async/await",
     });
     ```
   </Tab>
@@ -75,6 +87,7 @@ isol8 supports five runtimes with a shared execution contract (`ExecutionRequest
 | Bun | `bun -e <code>` | `bun run <file>` |
 | Deno | Engine writes file first | `deno run --allow-read=/sandbox,/tmp --allow-write=/sandbox,/tmp --allow-env --allow-net <file>` |
 | Bash | `bash -c <code>` | `bash <file>` |
+| Agent | `bash -c "pi --no-session [agentFlags] -p <prompt>"` | N/A (always inline prompt) |
 
 ## Package install behavior (`installPackages` / `--install`)
 
@@ -85,6 +98,7 @@ isol8 supports five runtimes with a shared execution contract (`ExecutionRequest
 | Bun | `bun install -g --global-dir=...` | `bun install -g ...` |
 | Deno | `deno cache ...` | `deno cache ...` |
 | Bash | `apk add --no-cache ...` | `apk add --no-cache ...` |
+| Agent | `bun install -g --global-dir=...` | `bun install -g ...` |
 
 <Note>
   Runtime installs are written under `/sandbox` so native extensions can execute (`/tmp` is `noexec`).
@@ -117,6 +131,16 @@ isol8 supports five runtimes with a shared execution contract (`ExecutionRequest
 - useful for shell orchestration and glue scripts
 - package installs use Alpine `apk`
 
+### Agent
+
+- runs the [pi coding agent](https://github.com/mariozechner/pi-coding-agent) inside the sandbox
+- the `-e` value is always treated as the **prompt text**, not code
+- requires `network: "filtered"` with at least one whitelist entry (the agent needs LLM API access)
+- defaults to higher resource limits: `pidsLimit: 200`, `sandboxSize: "2g"`
+- extra pi flags (e.g. `--model`, `--thinking`) are passed via `--agent-flags` (CLI) or `agentFlags` (library/API)
+- use `--files <dir>` to inject a local project directory into `/sandbox` for the agent to work on
+- file output after execution is the user's responsibility via the prompt
+
 ## FAQ
 
 <AccordionGroup>
@@ -125,7 +149,11 @@ isol8 supports five runtimes with a shared execution contract (`ExecutionRequest
   </Accordion>
 
   <Accordion title="Can I switch runtimes inside one persistent session?">
-    No. Persistent containers are runtime-bound. Use separate sessions for Python/Node/Bun/Deno/Bash.
+    No. Persistent containers are runtime-bound. Use separate sessions for Python/Node/Bun/Deno/Bash/Agent.
+  </Accordion>
+
+  <Accordion title="Why does the agent runtime require filtered networking?">
+    The agent needs to call an LLM API (e.g. Anthropic, OpenAI) to function. The engine enforces `network: "filtered"` with at least one whitelist entry to ensure the agent has controlled API access while preventing unrestricted network use.
   </Accordion>
 
   <Accordion title="Why do some packages fail on Alpine-based images?">

--- a/packages/core/docker/Dockerfile
+++ b/packages/core/docker/Dockerfile
@@ -40,3 +40,15 @@ CMD ["deno"]
 # ── Bash ──────────────────────────────────────────────────────────────
 FROM base AS bash
 CMD ["bash"]
+
+# ── Agent ─────────────────────────────────────────────────────────────
+FROM base AS agent
+RUN apk add --no-cache unzip libstdc++ libgcc \
+    && curl -fsSL https://bun.sh/install | bash \
+    && mv /root/.bun/bin/bun /usr/local/bin/bun \
+    && ln -s /usr/local/bin/bun /usr/local/bin/bunx \
+    && bun install -g @mariozechner/pi-coding-agent \
+    && cp -r /root/.bun/install /usr/local/share/bun-global \
+    && printf '#!/bin/sh\nexec bun /usr/local/share/bun-global/global/node_modules/@mariozechner/pi-coding-agent/dist/cli.js "$@"\n' > /usr/local/bin/pi \
+    && chmod +x /usr/local/bin/pi
+CMD ["bash"]

--- a/packages/core/schema/isol8.config.schema.json
+++ b/packages/core/schema/isol8.config.schema.json
@@ -204,6 +204,13 @@
           "enum": ["secure", "fast"],
           "type": "string"
         },
+        "prebuiltImages": {
+          "description": "Prebuilt custom images to build automatically during `isol8 setup` and `isol8 serve` startup. Images that already exist locally are skipped unless `--force` is passed.",
+          "items": {
+            "$ref": "#/definitions/PrebuiltImageConfig"
+          },
+          "type": "array"
+        },
         "remoteCode": {
           "additionalProperties": false,
           "description": "Remote code fetching policy. (Partial override allowed).",
@@ -273,6 +280,38 @@
     "NetworkMode": {
       "description": "Network access mode for isol8 containers.\n\n- `\"none\"` — All network access blocked (default, most secure).\n- `\"host\"` — Full host network access (use with caution).\n- `\"filtered\"` — HTTP/HTTPS traffic routed through a proxy that enforces   whitelist/blacklist regex rules on hostnames.",
       "enum": ["none", "host", "filtered"],
+      "type": "string"
+    },
+    "PrebuiltImageConfig": {
+      "additionalProperties": false,
+      "description": "Configuration for a prebuilt custom image that `isol8 setup` and `isol8 serve` ensure exists locally before accepting work.",
+      "properties": {
+        "installPackages": {
+          "description": "The runtime packages to install into the custom image (e.g. `[\"numpy\", \"pandas\"]`).",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "runtime": {
+          "$ref": "#/definitions/Runtime",
+          "description": "The base runtime to extend (e.g. `python`, `node`)."
+        },
+        "setupScript": {
+          "description": "Shell script baked into the image that runs automatically before every execution. Runs as `sandbox` user from `/sandbox` after package installation but before the main code.  When an execution request also carries its own `setupScript`, the image-level script runs first followed by the request-level script.",
+          "type": "string"
+        },
+        "tag": {
+          "description": "The full docker tag of the custom image to build (e.g. `my-custom-python:latest`).",
+          "type": "string"
+        }
+      },
+      "required": ["tag", "runtime", "installPackages"],
+      "type": "object"
+    },
+    "Runtime": {
+      "description": "Supported code execution runtimes.\n\n- `\"python\"` — CPython 3.x\n- `\"node\"` — Node.js LTS\n- `\"bun\"` — Bun runtime\n- `\"deno\"` — Deno runtime\n- `\"bash\"` — Bash shell\n- `\"agent\"` — AI coding agent (pi) running inside a sandboxed container",
+      "enum": ["python", "node", "bun", "deno", "bash", "agent"],
       "type": "string"
     },
     "SecurityConfig": {

--- a/packages/core/src/engine/docker.ts
+++ b/packages/core/src/engine/docker.ts
@@ -260,6 +260,7 @@ export class DockerIsol8 implements Isol8Engine {
     await this.semaphore.acquire();
     const startTime = Date.now();
     try {
+      this.validateAgentRuntime(req);
       const request = await this.resolveExecutionRequest(req);
       const result =
         this.mode === "persistent"
@@ -484,6 +485,7 @@ export class DockerIsol8 implements Isol8Engine {
   async *executeStream(req: ExecutionRequest): AsyncIterable<StreamEvent> {
     await this.semaphore.acquire();
     try {
+      this.validateAgentRuntime(req);
       const request = await this.resolveExecutionRequest(req);
       const adapter = this.getAdapter(request.runtime);
       const timeoutMs = request.timeoutMs ?? this.defaultTimeoutMs;
@@ -556,7 +558,7 @@ export class DockerIsol8 implements Isol8Engine {
         }
 
         // Build command
-        const rawCmd = adapter.getCommand(request.code, filePath);
+        const rawCmd = this.buildAdapterCommand(adapter, request, filePath);
         const timeoutSec = Math.ceil(timeoutMs / 1000);
         let cmd: string[];
         if (request.stdin) {
@@ -793,18 +795,18 @@ export class DockerIsol8 implements Isol8Engine {
       let rawCmd: string[];
       if (canUseInline) {
         try {
-          rawCmd = adapter.getCommand(req.code);
+          rawCmd = this.buildAdapterCommand(adapter, req);
         } catch {
           const ext = req.fileExtension ?? adapter.getFileExtension();
           const filePath = `${SANDBOX_WORKDIR}/main${ext}`;
           await this.volumeManager.writeFileViaExec(container, filePath, req.code);
-          rawCmd = adapter.getCommand(req.code, filePath);
+          rawCmd = this.buildAdapterCommand(adapter, req, filePath);
         }
       } else {
         const ext = req.fileExtension ?? adapter.getFileExtension();
         const filePath = `${SANDBOX_WORKDIR}/main${ext}`;
         await this.volumeManager.writeFileViaExec(container, filePath, req.code);
-        rawCmd = adapter.getCommand(req.code, filePath);
+        rawCmd = this.buildAdapterCommand(adapter, req, filePath);
       }
 
       // Install packages if requested
@@ -982,7 +984,7 @@ export class DockerIsol8 implements Isol8Engine {
       }
     }
 
-    const rawCmd = adapter.getCommand(req.code, filePath);
+    const rawCmd = this.buildAdapterCommand(adapter, req, filePath);
     const timeoutSec = Math.ceil(timeoutMs / 1000);
 
     // Install packages if requested
@@ -1161,6 +1163,52 @@ export class DockerIsol8 implements Isol8Engine {
     return RuntimeRegistry.get(runtime);
   }
 
+  /**
+   * Validate agent runtime requirements. The agent runtime requires
+   * filtered network mode with at least one whitelist entry so that
+   * the AI coding agent can reach its LLM provider API.
+   */
+  private validateAgentRuntime(req: ExecutionRequest): void {
+    if (req.runtime !== "agent") {
+      return;
+    }
+
+    if (this.network !== "filtered") {
+      throw new Error(
+        'Agent runtime requires network mode "filtered". ' +
+          "The AI coding agent needs network access to reach its LLM provider API. " +
+          'Use --net filtered --allow "api.anthropic.com" (or your provider\'s domain).'
+      );
+    }
+
+    const whitelist = this.networkFilter?.whitelist ?? [];
+    if (whitelist.length === 0) {
+      throw new Error(
+        "Agent runtime requires at least one network whitelist entry. " +
+          "The AI coding agent needs to reach its LLM provider API. " +
+          'Use --allow "api.anthropic.com" (or your provider\'s domain).'
+      );
+    }
+  }
+
+  /**
+   * Build the execution command from the adapter. Prefers `getCommandWithOptions`
+   * when the adapter implements it, otherwise falls back to `getCommand`.
+   */
+  private buildAdapterCommand(
+    adapter: RuntimeAdapter,
+    req: ExecutionRequest & { code: string },
+    filePath?: string
+  ): string[] {
+    if (adapter.getCommandWithOptions) {
+      return adapter.getCommandWithOptions(req.code, {
+        filePath,
+        agentFlags: req.agentFlags,
+      });
+    }
+    return adapter.getCommand(req.code, filePath);
+  }
+
   private buildHostConfig(): Docker.HostConfig {
     const config: Docker.HostConfig = {
       Memory: parseMemoryLimit(this.memoryLimit),
@@ -1269,9 +1317,11 @@ export class DockerIsol8 implements Isol8Engine {
    * }
    * ```
    */
-  static async cleanup(
-    docker?: Docker
-  ): Promise<{ removed: number; failed: number; errors: string[] }> {
+  static async cleanup(docker?: Docker): Promise<{
+    removed: number;
+    failed: number;
+    errors: string[];
+  }> {
     const dockerInstance = docker ?? new Docker();
 
     // Find all isol8 containers
@@ -1303,9 +1353,11 @@ export class DockerIsol8 implements Isol8Engine {
    * Images are identified by repo tags starting with `isol8:`
    * (for example `isol8:python` or `isol8:python-custom-<hash>`).
    */
-  static async cleanupImages(
-    docker?: Docker
-  ): Promise<{ removed: number; failed: number; errors: string[] }> {
+  static async cleanupImages(docker?: Docker): Promise<{
+    removed: number;
+    failed: number;
+    errors: string[];
+  }> {
     const dockerInstance = docker ?? new Docker();
 
     const images = await dockerInstance.listImages({ all: true });

--- a/packages/core/src/engine/managers/execution-manager.ts
+++ b/packages/core/src/engine/managers/execution-manager.ts
@@ -43,6 +43,8 @@ export class ExecutionManager {
         return ["npm", "install", "--prefix", "/sandbox", ...packages];
       case "bun":
         return ["bun", "install", "-g", "--global-dir=/sandbox/.bun-global", ...packages];
+      case "agent":
+        return ["bun", "install", "-g", "--global-dir=/sandbox/.bun-global", ...packages];
       case "deno":
         return ["sh", "-c", packages.map((p) => `deno cache ${p}`).join(" && ")];
       case "bash":
@@ -78,7 +80,7 @@ export class ExecutionManager {
       env.push("npm_config_fetch_retry_mintimeout=1000");
       env.push("NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT=2000");
       env.push("npm_config_fetch_retry_maxtimeout=2000");
-    } else if (runtime === "bun") {
+    } else if (runtime === "bun" || runtime === "agent") {
       env.push("BUN_INSTALL_GLOBAL_DIR=/sandbox/.bun-global");
       env.push("BUN_INSTALL_CACHE_DIR=/sandbox/.bun-cache");
       env.push("BUN_INSTALL_BIN=/sandbox/.bun-global/bin");

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -24,6 +24,7 @@ export {
 } from "./engine/image-builder";
 // ─── Runtime ───
 export {
+  AgentAdapter,
   BunAdapter,
   bashAdapter,
   DenoAdapter,
@@ -31,7 +32,7 @@ export {
   PythonAdapter,
   RuntimeRegistry,
 } from "./runtime";
-export type { RuntimeAdapter } from "./runtime/adapter";
+export type { RuntimeAdapter, RuntimeCommandOptions } from "./runtime/adapter";
 // ─── Types ───
 export type {
   AuthConfig,

--- a/packages/core/src/runtime/adapter.ts
+++ b/packages/core/src/runtime/adapter.ts
@@ -8,6 +8,17 @@
 import type { Runtime } from "../types";
 
 /**
+ * Options passed to {@link RuntimeAdapter.getCommandWithOptions} for runtimes
+ * that need additional context beyond the source code.
+ */
+export interface RuntimeCommandOptions {
+  /** Path to the code file inside the container, if written to disk. */
+  filePath?: string;
+  /** Extra CLI flags for the agent runtime (e.g. `"--model anthropic/claude-sonnet-4"`). */
+  agentFlags?: string;
+}
+
+/**
  * A runtime adapter provides the container image and command construction
  * for a specific language runtime (Python, Node, Bun, Deno).
  *
@@ -29,6 +40,17 @@ export interface RuntimeAdapter {
    * @returns Command array (e.g. `["python3", "-c", "print(1)"]`).
    */
   getCommand(code: string, filePath?: string): string[];
+
+  /**
+   * Build the shell command with extended options.
+   * When implemented, the engine calls this instead of {@link getCommand}.
+   * Used by runtimes that need additional context (e.g. agent flags).
+   *
+   * @param code - The source code or prompt string.
+   * @param options - Extended command options.
+   * @returns Command array.
+   */
+  getCommandWithOptions?(code: string, options: RuntimeCommandOptions): string[];
 
   /** Default file extension for this runtime (e.g. `".py"`). */
   getFileExtension(): string;

--- a/packages/core/src/runtime/adapters/agent.ts
+++ b/packages/core/src/runtime/adapters/agent.ts
@@ -1,0 +1,44 @@
+/**
+ * @module runtime/adapters/agent
+ *
+ * Runtime adapter for the AI coding agent (pi from @mariozechner/pi-coding-agent).
+ * Runs pi in non-interactive print mode inside a sandboxed container with bun + git.
+ */
+
+import type { RuntimeAdapter, RuntimeCommandOptions } from "../adapter";
+
+/**
+ * Shell-escape a string for safe embedding inside single quotes.
+ * Replaces each `'` with `'\''` (end quote, escaped quote, start quote).
+ */
+function shellQuote(s: string): string {
+  return `'${s.replace(/'/g, "'\\''")}'`;
+}
+
+/**
+ * Agent runtime adapter.
+ *
+ * Uses the `pi` CLI (`@mariozechner/pi-coding-agent`) to run an AI coding agent
+ * inside the container. The `code` field is treated as the prompt text.
+ *
+ * Always runs in non-interactive mode (`--no-session -p <prompt>`).
+ * Extra flags (e.g. `--model`, `--thinking`) are passed via `agentFlags`.
+ */
+export const AgentAdapter: RuntimeAdapter = {
+  name: "agent",
+  image: "isol8:agent",
+
+  getCommand(code: string): string[] {
+    return ["bash", "-c", `pi --no-session -p ${shellQuote(code)}`];
+  },
+
+  getCommandWithOptions(code: string, options: RuntimeCommandOptions): string[] {
+    const flags = options.agentFlags ? `${options.agentFlags} ` : "";
+    return ["bash", "-c", `pi --no-session ${flags}-p ${shellQuote(code)}`];
+  },
+
+  getFileExtension(): string {
+    // Agent prompts are plain text; .txt avoids collisions with other runtimes.
+    return ".txt";
+  },
+};

--- a/packages/core/src/runtime/adapters/agent.ts
+++ b/packages/core/src/runtime/adapters/agent.ts
@@ -16,6 +16,18 @@ function shellQuote(s: string): string {
 }
 
 /**
+ * Injected into every pi invocation via --append-system-prompt.
+ * Keeps the agent aware of sandbox constraints without replacing pi's default prompt.
+ */
+const SANDBOX_SYSTEM_PROMPT =
+  "You are running inside an isol8 sandbox — a Docker container with strict " +
+  "resource limits and controlled network access. isol8 exists to execute " +
+  "untrusted code safely: outbound network is filtered to a whitelist, the " +
+  "filesystem is ephemeral, and some system calls are restricted. Work within " +
+  "these constraints: do not assume open internet access, do not rely on " +
+  "persistent state across runs, and do not attempt to escape the sandbox.";
+
+/**
  * Agent runtime adapter.
  *
  * Uses the `pi` CLI (`@mariozechner/pi-coding-agent`) to run an AI coding agent
@@ -23,18 +35,27 @@ function shellQuote(s: string): string {
  *
  * Always runs in non-interactive mode (`--no-session -p <prompt>`).
  * Extra flags (e.g. `--model`, `--thinking`) are passed via `agentFlags`.
+ * A fixed system prompt is appended to every invocation via `--append-system-prompt`.
  */
 export const AgentAdapter: RuntimeAdapter = {
   name: "agent",
   image: "isol8:agent",
 
   getCommand(code: string): string[] {
-    return ["bash", "-c", `pi --no-session -p ${shellQuote(code)}`];
+    return [
+      "bash",
+      "-c",
+      `pi --no-session --append-system-prompt ${shellQuote(SANDBOX_SYSTEM_PROMPT)} -p ${shellQuote(code)}`,
+    ];
   },
 
   getCommandWithOptions(code: string, options: RuntimeCommandOptions): string[] {
     const flags = options.agentFlags ? `${options.agentFlags} ` : "";
-    return ["bash", "-c", `pi --no-session ${flags}-p ${shellQuote(code)}`];
+    return [
+      "bash",
+      "-c",
+      `pi --no-session --append-system-prompt ${shellQuote(SANDBOX_SYSTEM_PROMPT)} ${flags}-p ${shellQuote(code)}`,
+    ];
   },
 
   getFileExtension(): string {

--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -3,10 +3,11 @@
  *
  * Barrel module that registers all built-in runtime adapters and re-exports
  * the public API. Importing this module has the side effect of populating
- * the {@link RuntimeRegistry} with Python, Node, Bun, and Deno adapters.
+ * the {@link RuntimeRegistry} with Python, Node, Bun, Deno, Bash, and Agent adapters.
  */
 
 import { RuntimeRegistry } from "./adapter";
+import { AgentAdapter } from "./adapters/agent";
 import { bashAdapter } from "./adapters/bash";
 import { BunAdapter } from "./adapters/bun";
 import { DenoAdapter } from "./adapters/deno";
@@ -19,9 +20,11 @@ RuntimeRegistry.register(NodeAdapter, [".js", ".cjs"]);
 RuntimeRegistry.register(BunAdapter); // Bun wins for .ts
 RuntimeRegistry.register(bashAdapter);
 RuntimeRegistry.register(DenoAdapter); // Deno uses .mts to avoid extension collision
+RuntimeRegistry.register(AgentAdapter);
 
-export type { RuntimeAdapter } from "./adapter";
+export type { RuntimeAdapter, RuntimeCommandOptions } from "./adapter";
 export { RuntimeRegistry } from "./adapter";
+export { AgentAdapter } from "./adapters/agent";
 export { bashAdapter } from "./adapters/bash";
 export { BunAdapter } from "./adapters/bun";
 export { DenoAdapter } from "./adapters/deno";

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -15,8 +15,9 @@
  * - `"bun"` — Bun runtime
  * - `"deno"` — Deno runtime
  * - `"bash"` — Bash shell
+ * - `"agent"` — AI coding agent (pi) running inside a sandboxed container
  */
-export type Runtime = "python" | "node" | "bun" | "deno" | "bash";
+export type Runtime = "python" | "node" | "bun" | "deno" | "bash" | "agent";
 
 /**
  * Network access mode for isol8 containers.
@@ -118,6 +119,14 @@ export interface ExecutionRequest {
    * @default "/sandbox"
    */
   workdir?: string;
+
+  /**
+   * Extra CLI flags passed to the AI coding agent (pi).
+   * Only used when `runtime` is `"agent"`.
+   * These flags are prepended before the `-p` prompt flag in the command.
+   * @example "--model anthropic/claude-sonnet-4 --thinking"
+   */
+  agentFlags?: string;
 }
 
 /**
@@ -615,16 +624,17 @@ export interface Isol8Config {
   debug: boolean;
 
   /**
-   * Prebuilt images ensuring that custom environments are built and ready
-   * when the server starts. The server will invoke `isol8 build` on these images
-   * automatically during boot if they are not already built locally.
-   * Only applicable in server-mode.
+   * Prebuilt custom images ensuring that environments are built and ready.
+   * Both `isol8 setup` and `isol8 serve` will build any missing images
+   * automatically. Images that already exist locally are skipped unless
+   * `--force` is passed.
    */
   prebuiltImages: PrebuiltImageConfig[];
 }
 
 /**
- * Configuration for a prebuilt image that the server ensures exists.
+ * Configuration for a prebuilt custom image that `isol8 setup` and
+ * `isol8 serve` ensure exists locally before accepting work.
  */
 export interface PrebuiltImageConfig {
   /** The full docker tag of the custom image to build (e.g. `my-custom-python:latest`). */
@@ -689,4 +699,11 @@ export interface Isol8UserConfig {
 
   /** Database-backed API key authentication configuration. */
   auth?: Partial<AuthConfig>;
+
+  /**
+   * Prebuilt custom images to build automatically during `isol8 setup` and
+   * `isol8 serve` startup. Images that already exist locally are skipped
+   * unless `--force` is passed.
+   */
+  prebuiltImages?: PrebuiltImageConfig[];
 }

--- a/packages/core/tests/unit/agent-adapter.test.ts
+++ b/packages/core/tests/unit/agent-adapter.test.ts
@@ -5,6 +5,18 @@ import { AgentAdapter } from "../../src/runtime/adapters/agent";
 // Import to register all adapters including agent
 import "../../src/runtime";
 
+// Mirror of the constant in agent.ts — kept in sync to catch drift.
+const SP =
+  "You are running inside an isol8 sandbox — a Docker container with strict " +
+  "resource limits and controlled network access. isol8 exists to execute " +
+  "untrusted code safely: outbound network is filtered to a whitelist, the " +
+  "filesystem is ephemeral, and some system calls are restricted. Work within " +
+  "these constraints: do not assume open internet access, do not rely on " +
+  "persistent state across runs, and do not attempt to escape the sandbox.";
+
+/** Shell-quoted version of SP for embedding in expected command strings. */
+const SP_Q = `'${SP}'`;
+
 describe("AgentAdapter", () => {
   test("is registered in RuntimeRegistry", () => {
     const adapter = RuntimeRegistry.get("agent");
@@ -23,40 +35,52 @@ describe("AgentAdapter", () => {
 
   // ── getCommand (basic, no agent flags) ──
 
-  test("getCommand wraps prompt in pi --no-session -p", () => {
+  test("getCommand wraps prompt in pi --no-session --append-system-prompt ... -p", () => {
     const cmd = AgentAdapter.getCommand("Write hello world");
-    expect(cmd).toEqual(["bash", "-c", "pi --no-session -p 'Write hello world'"]);
+    expect(cmd).toEqual([
+      "bash",
+      "-c",
+      `pi --no-session --append-system-prompt ${SP_Q} -p 'Write hello world'`,
+    ]);
   });
 
   test("getCommand shell-escapes single quotes in prompt", () => {
     const cmd = AgentAdapter.getCommand("it's a test");
-    expect(cmd).toEqual(["bash", "-c", "pi --no-session -p 'it'\\''s a test'"]);
+    expect(cmd).toEqual([
+      "bash",
+      "-c",
+      `pi --no-session --append-system-prompt ${SP_Q} -p 'it'\\''s a test'`,
+    ]);
   });
 
   test("getCommand handles empty prompt", () => {
     const cmd = AgentAdapter.getCommand("");
-    expect(cmd).toEqual(["bash", "-c", "pi --no-session -p ''"]);
+    expect(cmd).toEqual(["bash", "-c", `pi --no-session --append-system-prompt ${SP_Q} -p ''`]);
   });
 
   test("getCommand handles prompt with special shell characters", () => {
     const cmd = AgentAdapter.getCommand('echo "hello" | grep $VAR && rm -rf /');
-    // Only single quotes need escaping inside single-quoted strings
     expect(cmd[0]).toBe("bash");
     expect(cmd[1]).toBe("-c");
-    expect(cmd[2]).toContain("pi --no-session -p ");
+    expect(cmd[2]).toContain(`--append-system-prompt ${SP_Q}`);
     expect(cmd[2]).toContain('echo "hello" | grep $VAR && rm -rf /');
   });
 
   test("getCommand handles prompt with newlines", () => {
     const cmd = AgentAdapter.getCommand("line1\nline2");
     expect(cmd[2]).toContain("line1\nline2");
+    expect(cmd[2]).toContain(`--append-system-prompt ${SP_Q}`);
   });
 
   // ── getCommandWithOptions ──
 
   test("getCommandWithOptions without agentFlags behaves like getCommand", () => {
     const cmd = AgentAdapter.getCommandWithOptions!("hello", {});
-    expect(cmd).toEqual(["bash", "-c", "pi --no-session -p 'hello'"]);
+    expect(cmd).toEqual([
+      "bash",
+      "-c",
+      `pi --no-session --append-system-prompt ${SP_Q} -p 'hello'`,
+    ]);
   });
 
   test("getCommandWithOptions with agentFlags prepends flags before -p", () => {
@@ -66,7 +90,7 @@ describe("AgentAdapter", () => {
     expect(cmd).toEqual([
       "bash",
       "-c",
-      "pi --no-session --model anthropic/claude-sonnet-4 --thinking -p 'hello'",
+      `pi --no-session --append-system-prompt ${SP_Q} --model anthropic/claude-sonnet-4 --thinking -p 'hello'`,
     ]);
   });
 
@@ -75,7 +99,7 @@ describe("AgentAdapter", () => {
       agentFlags: "--model openai/gpt-4o",
     });
     expect(cmd[2]).toBe(
-      "pi --no-session --model openai/gpt-4o -p 'it'\\''s a '\\''quoted'\\'' test'"
+      `pi --no-session --append-system-prompt ${SP_Q} --model openai/gpt-4o -p 'it'\\''s a '\\''quoted'\\'' test'`
     );
   });
 
@@ -84,7 +108,11 @@ describe("AgentAdapter", () => {
       filePath: "/sandbox/prompt.txt",
     });
     // filePath is ignored — agent always inlines prompt via -p
-    expect(cmd).toEqual(["bash", "-c", "pi --no-session -p 'hello'"]);
+    expect(cmd).toEqual([
+      "bash",
+      "-c",
+      `pi --no-session --append-system-prompt ${SP_Q} -p 'hello'`,
+    ]);
   });
 
   test("getCommandWithOptions with empty agentFlags", () => {
@@ -92,6 +120,10 @@ describe("AgentAdapter", () => {
       agentFlags: "",
     });
     // Empty string should not add extra spaces
-    expect(cmd).toEqual(["bash", "-c", "pi --no-session -p 'hello'"]);
+    expect(cmd).toEqual([
+      "bash",
+      "-c",
+      `pi --no-session --append-system-prompt ${SP_Q} -p 'hello'`,
+    ]);
   });
 });

--- a/packages/core/tests/unit/agent-adapter.test.ts
+++ b/packages/core/tests/unit/agent-adapter.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "bun:test";
+import { RuntimeRegistry } from "../../src/runtime";
+import { AgentAdapter } from "../../src/runtime/adapters/agent";
+
+// Import to register all adapters including agent
+import "../../src/runtime";
+
+describe("AgentAdapter", () => {
+  test("is registered in RuntimeRegistry", () => {
+    const adapter = RuntimeRegistry.get("agent");
+    expect(adapter.name).toBe("agent");
+    expect(adapter.image).toBe("isol8:agent");
+  });
+
+  test("appears in RuntimeRegistry.list()", () => {
+    const names = RuntimeRegistry.list().map((a) => a.name);
+    expect(names).toContain("agent");
+  });
+
+  test("file extension is .txt", () => {
+    expect(AgentAdapter.getFileExtension()).toBe(".txt");
+  });
+
+  // ── getCommand (basic, no agent flags) ──
+
+  test("getCommand wraps prompt in pi --no-session -p", () => {
+    const cmd = AgentAdapter.getCommand("Write hello world");
+    expect(cmd).toEqual(["bash", "-c", "pi --no-session -p 'Write hello world'"]);
+  });
+
+  test("getCommand shell-escapes single quotes in prompt", () => {
+    const cmd = AgentAdapter.getCommand("it's a test");
+    expect(cmd).toEqual(["bash", "-c", "pi --no-session -p 'it'\\''s a test'"]);
+  });
+
+  test("getCommand handles empty prompt", () => {
+    const cmd = AgentAdapter.getCommand("");
+    expect(cmd).toEqual(["bash", "-c", "pi --no-session -p ''"]);
+  });
+
+  test("getCommand handles prompt with special shell characters", () => {
+    const cmd = AgentAdapter.getCommand('echo "hello" | grep $VAR && rm -rf /');
+    // Only single quotes need escaping inside single-quoted strings
+    expect(cmd[0]).toBe("bash");
+    expect(cmd[1]).toBe("-c");
+    expect(cmd[2]).toContain("pi --no-session -p ");
+    expect(cmd[2]).toContain('echo "hello" | grep $VAR && rm -rf /');
+  });
+
+  test("getCommand handles prompt with newlines", () => {
+    const cmd = AgentAdapter.getCommand("line1\nline2");
+    expect(cmd[2]).toContain("line1\nline2");
+  });
+
+  // ── getCommandWithOptions ──
+
+  test("getCommandWithOptions without agentFlags behaves like getCommand", () => {
+    const cmd = AgentAdapter.getCommandWithOptions!("hello", {});
+    expect(cmd).toEqual(["bash", "-c", "pi --no-session -p 'hello'"]);
+  });
+
+  test("getCommandWithOptions with agentFlags prepends flags before -p", () => {
+    const cmd = AgentAdapter.getCommandWithOptions!("hello", {
+      agentFlags: "--model anthropic/claude-sonnet-4 --thinking",
+    });
+    expect(cmd).toEqual([
+      "bash",
+      "-c",
+      "pi --no-session --model anthropic/claude-sonnet-4 --thinking -p 'hello'",
+    ]);
+  });
+
+  test("getCommandWithOptions with agentFlags and complex prompt", () => {
+    const cmd = AgentAdapter.getCommandWithOptions!("it's a 'quoted' test", {
+      agentFlags: "--model openai/gpt-4o",
+    });
+    expect(cmd[2]).toBe(
+      "pi --no-session --model openai/gpt-4o -p 'it'\\''s a '\\''quoted'\\'' test'"
+    );
+  });
+
+  test("getCommandWithOptions ignores filePath (agent always uses -p)", () => {
+    const cmd = AgentAdapter.getCommandWithOptions!("hello", {
+      filePath: "/sandbox/prompt.txt",
+    });
+    // filePath is ignored — agent always inlines prompt via -p
+    expect(cmd).toEqual(["bash", "-c", "pi --no-session -p 'hello'"]);
+  });
+
+  test("getCommandWithOptions with empty agentFlags", () => {
+    const cmd = AgentAdapter.getCommandWithOptions!("hello", {
+      agentFlags: "",
+    });
+    // Empty string should not add extra spaces
+    expect(cmd).toEqual(["bash", "-c", "pi --no-session -p 'hello'"]);
+  });
+});

--- a/packages/core/tests/unit/agent-validation.test.ts
+++ b/packages/core/tests/unit/agent-validation.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, mock, test } from "bun:test";
+import type Docker from "dockerode";
+import { DockerIsol8 } from "../../src/engine/docker";
+
+/**
+ * Tests for the agent runtime validation logic in DockerIsol8.
+ *
+ * The engine enforces that agent runtime executions use network: "filtered"
+ * with at least one whitelist entry. These tests verify that constraint
+ * via the public execute() API.
+ */
+describe("Agent runtime validation", () => {
+  const createMockDocker = () => {
+    const removeMock = mock(() => Promise.resolve());
+
+    const execInspect = mock(() => Promise.resolve({ Running: false, ExitCode: 0 }));
+    const execStartStream = {
+      on: mock((event: string, cb: (...args: unknown[]) => void) => {
+        if (event === "end") {
+          setTimeout(() => cb(), 0);
+        }
+        return execStartStream;
+      }),
+    };
+    const execStart = mock(() => Promise.resolve(execStartStream));
+
+    const containerExec = mock(() =>
+      Promise.resolve({
+        start: execStart,
+        inspect: execInspect,
+      })
+    );
+
+    const container = {
+      id: "mock-container-id",
+      start: mock(() => Promise.resolve()),
+      stop: mock(() => Promise.resolve()),
+      exec: containerExec,
+      inspect: mock(() => Promise.resolve({ State: { Running: true } })),
+      remove: removeMock,
+      modem: { demuxStream: mock() },
+    } as unknown as Docker.Container;
+
+    const createContainer = mock(() => Promise.resolve(container));
+    const getImage = mock(() => ({
+      inspect: mock(() => Promise.reject(new Error("no custom image"))),
+    }));
+
+    const docker = {
+      createContainer,
+      getImage,
+    } as unknown as Docker;
+
+    return { docker, container, createContainer, removeMock };
+  };
+
+  // ── Validation: network mode ──
+
+  test("rejects agent runtime with network: 'none'", async () => {
+    const { docker } = createMockDocker();
+    const engine = new DockerIsol8({
+      docker,
+      mode: "ephemeral",
+      network: "none",
+    });
+
+    await expect(
+      engine.execute({
+        code: "Write hello world",
+        runtime: "agent",
+      })
+    ).rejects.toThrow('Agent runtime requires network mode "filtered"');
+  });
+
+  test("rejects agent runtime with network: 'host'", async () => {
+    const { docker } = createMockDocker();
+    const engine = new DockerIsol8({
+      docker,
+      mode: "ephemeral",
+      network: "host",
+    });
+
+    await expect(
+      engine.execute({
+        code: "Write hello world",
+        runtime: "agent",
+      })
+    ).rejects.toThrow('Agent runtime requires network mode "filtered"');
+  });
+
+  // ── Validation: whitelist required ──
+
+  test("rejects agent runtime with empty whitelist", async () => {
+    const { docker } = createMockDocker();
+    const engine = new DockerIsol8({
+      docker,
+      mode: "ephemeral",
+      network: "filtered",
+      networkFilter: {
+        whitelist: [],
+        blacklist: [],
+      },
+    });
+
+    await expect(
+      engine.execute({
+        code: "Write hello world",
+        runtime: "agent",
+      })
+    ).rejects.toThrow("Agent runtime requires at least one network whitelist entry");
+  });
+
+  test("rejects agent runtime with filtered network but no networkFilter", async () => {
+    const { docker } = createMockDocker();
+    const engine = new DockerIsol8({
+      docker,
+      mode: "ephemeral",
+      network: "filtered",
+      // No networkFilter → whitelist defaults to empty
+    });
+
+    await expect(
+      engine.execute({
+        code: "Write hello world",
+        runtime: "agent",
+      })
+    ).rejects.toThrow("Agent runtime requires at least one network whitelist entry");
+  });
+
+  // ── Validation: valid configurations ──
+
+  test("accepts agent runtime with filtered network and whitelist", () => {
+    const { docker } = createMockDocker();
+    // Construction should succeed — validation happens in execute()
+    const engine = new DockerIsol8({
+      docker,
+      mode: "ephemeral",
+      network: "filtered",
+      networkFilter: {
+        whitelist: ["^api\\.anthropic\\.com$"],
+        blacklist: [],
+      },
+    });
+    expect(engine).toBeDefined();
+  });
+
+  // ── Non-agent runtimes skip validation ──
+
+  test("non-agent runtimes are not affected by agent validation", async () => {
+    const { docker } = createMockDocker();
+    const engine = new DockerIsol8({
+      docker,
+      mode: "ephemeral",
+      network: "none",
+    });
+
+    // Python with network: none should NOT throw the agent validation error
+    // (it may fail for other mock-related reasons, but NOT with the agent error)
+    try {
+      await engine.execute({
+        code: 'print("hello")',
+        runtime: "python",
+      });
+    } catch (e: unknown) {
+      const msg = (e as Error).message;
+      expect(msg).not.toContain("Agent runtime requires");
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Add a new first-class `agent` runtime that runs the [pi coding agent](https://github.com/mariozechner/pi-coding-agent) (`@mariozechner/pi-coding-agent`) inside sandboxed Docker containers
- Add CLI flags `--agent-flags` (pass extra pi flags like `--model`, `--thinking`) and `--files` (recursively inject a local directory into the container)
- Enforce `network: "filtered"` with at least one whitelist entry for agent executions, with descriptive error messages
- Fix `prebuiltImages` missing from `Isol8UserConfig` type and regenerated JSON schema

## Changes

### Core (`@isol8/core`)
- **types.ts**: Added `"agent"` to `Runtime` union, `agentFlags?: string` to `ExecutionRequest`, `prebuiltImages` to `Isol8UserConfig`
- **runtime/adapter.ts**: Added `RuntimeCommandOptions` interface and optional `getCommandWithOptions()` to `RuntimeAdapter`
- **runtime/adapters/agent.ts**: New `AgentAdapter` with shell-safe quoting, `getCommand`, `getCommandWithOptions`
- **runtime/index.ts**: Register `AgentAdapter`
- **engine/docker.ts**: Added `validateAgentRuntime()` (enforces filtered network + whitelist), `buildAdapterCommand()` helper, updated all adapter command call sites
- **engine/managers/execution-manager.ts**: Added `"agent"` case to `getInstallCommand()` and env config
- **docker/Dockerfile**: New `agent` stage (Alpine + bun + git + pi, accessible to sandbox user)
- **schema/isol8.config.schema.json**: Regenerated with `prebuiltImages` and `agent` in Runtime enum

### CLI (`@isol8/cli`)
- Added `--agent-flags` and `--files` options to `run` command
- Agent defaults: `pidsLimit: 200`, `sandboxSize: "2g"`
- `readDirectoryRecursive()` helper with skip patterns (`.git`, `node_modules`, etc.)

### Tests
- **Unit** (19 new): `agent-adapter.test.ts` (command generation, shell quoting, flags), `agent-validation.test.ts` (network mode/whitelist enforcement)
- **Integration** (9 new): `agent.test.ts` (validation, container environment — pi/bun/git/bash available, file injection)

### Documentation
- Updated README, SKILL.md, and all relevant docs pages (runtimes, cli, execution, option-mapping, index)
- Added changeset (`minor` for all packages)

## Testing

- 168 unit tests pass (19 new + 149 existing)
- 9 integration tests pass (agent-specific, Docker required)
- Lint clean
- Build passes