### PR TITLE
feat: add cmd field, StreamEvent.phase, and rewrite one-shot coding agents guide

### DIFF
--- a/.changeset/add-cmd-field.md
+++ b/.changeset/add-cmd-field.md
@@ -1,0 +1,12 @@
+---
+"@isol8/core": minor
+"@isol8/cli": minor
+---
+
+Add `cmd` field to `ExecutionRequest` for running arbitrary bash commands in the sandbox.
+
+`cmd` lets users execute bash commands directly inside the sandbox container via `bash -c "<cmd>"`, bypassing the runtime-specific code execution path. It is mutually exclusive with `code` and `codeUrl` — providing more than one is a validation error.
+
+- `ExecutionRequest.cmd?: string` — runs via `bash -c` in all runtimes
+- All four execute paths (`executeEphemeral`, `executePersistent`, `executeStreamEphemeral`, `executeStreamPersistent`) handle the `cmd` branch
+- CLI gains a `--cmd <command>` flag; defaults runtime to `bash` if not specified

--- a/.changeset/fix-execute-stream-persistent-mode.md
+++ b/.changeset/fix-execute-stream-persistent-mode.md
@@ -1,0 +1,12 @@
+---
+"@isol8/core": patch
+"@isol8/server": patch
+---
+
+Fix `executeStream` to properly support persistent mode and warm container pool.
+
+`executeStream` was always spinning up a brand-new ephemeral container, ignoring both the `mode: "persistent"` setting (so filesystem state was never preserved across streaming calls) and the pre-warmed container pool (so every streaming call paid full cold-start overhead). The server's `/execute/stream` (SSE) and `/execute/ws` (WebSocket) endpoints were also hardcoding `mode: "ephemeral"` and ignoring `sessionId`.
+
+- `executeStream` now dispatches to `executeStreamPersistent` (reuses `this.container`, preserving state) or `executeStreamEphemeral` (acquires from and returns to the warm pool) based on `this.mode`, matching the behaviour of `execute`
+- `WsClientMessage` execute variant gains an optional `sessionId` field
+- Server `/execute/stream` and `/execute/ws` now support `sessionId` for persistent streaming sessions, consistent with `/execute`

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -284,6 +284,10 @@ program
   .description("Execute code in isol8")
   .argument("[file]", "Script file to execute")
   .option("-e, --eval <code>", "Execute inline code string")
+  .option(
+    "--cmd <command>",
+    "Run bash command(s) in the sandbox (mutually exclusive with code input)"
+  )
   .option("-r, --runtime <name>", "Force runtime (python, node, bun, deno, bash)")
   .option("--net <mode>", "Network mode: none, host, filtered", "none")
   .option("--allow <regex>", "Whitelist regex for filtered mode (repeatable)", collect, [])
@@ -331,6 +335,7 @@ program
   .action(async (file: string | undefined, opts) => {
     const {
       code,
+      cmd,
       codeUrl,
       codeHash,
       allowInsecureCodeUrl,
@@ -346,9 +351,14 @@ program
     logger.debug(`[Run] Runtime: ${runtime}, mode: ${engineOptions.mode}`);
     logger.debug(`[Run] Network: ${engineOptions.network}, timeout: ${engineOptions.timeoutMs}ms`);
     logger.debug(`[Run] Memory: ${engineOptions.memoryLimit}, CPU: ${engineOptions.cpuLimit}`);
-    logger.debug(`[Run] Code source: ${codeUrl ? `url=${codeUrl}` : "inline/file/stdin"}`);
+    logger.debug(
+      `[Run] Code source: ${codeUrl ? `url=${codeUrl}` : cmd ? "cmd" : "inline/file/stdin"}`
+    );
     if (code) {
       logger.debug(`[Run] Code length: ${code.length} chars`);
+    }
+    if (cmd) {
+      logger.debug(`[Run] Cmd: ${cmd}`);
     }
     if (stdinData) {
       logger.debug(`[Run] Stdin data provided (${stdinData.length} chars)`);
@@ -393,6 +403,7 @@ program
         runtime,
         timeoutMs: engineOptions.timeoutMs,
         ...(code ? { code } : {}),
+        ...(cmd ? { cmd } : {}),
         ...(codeUrl ? { codeUrl } : {}),
         ...(codeHash ? { codeHash } : {}),
         ...(allowInsecureCodeUrl ? { allowInsecureCodeUrl } : {}),
@@ -1376,12 +1387,23 @@ async function resolveRunInput(file: string | undefined, opts: any) {
   const hasExplicitNetFlag = process.argv.some((arg) => arg === "--net");
 
   let code: string | undefined;
+  let cmd: string | undefined;
   let codeUrl: string | undefined;
   let codeHash: string | undefined;
   let allowInsecureCodeUrl = false;
   let runtime: Runtime;
 
-  if (opts.url || opts.github || opts.gist) {
+  if (opts.cmd) {
+    if (file || opts.eval || opts.url || opts.github || opts.gist) {
+      console.error(
+        "[ERR] --cmd cannot be combined with file input, --eval, --url, --github, or --gist."
+      );
+      process.exit(1);
+    }
+    cmd = opts.cmd;
+    runtime = (opts.runtime ?? "bash") as Runtime;
+    logger.debug(`[Run] cmd mode, runtime: ${runtime}`);
+  } else if (opts.url || opts.github || opts.gist) {
     if (file || opts.eval) {
       console.error("[ERR] --url/--github/--gist cannot be used with file input or --eval.");
       process.exit(1);
@@ -1546,6 +1568,7 @@ async function resolveRunInput(file: string | undefined, opts: any) {
 
   return {
     code,
+    cmd,
     codeUrl,
     codeHash,
     allowInsecureCodeUrl,

--- a/apps/cli/tests/integration/agent.test.ts
+++ b/apps/cli/tests/integration/agent.test.ts
@@ -10,7 +10,7 @@ import { hasDocker } from "./setup";
  * we test:
  * - The pi binary is accessible and runnable
  * - The container has required tools (bun, git, bash)
- * - The agent validation logic (filtered network + whitelist required)
+ * - The agent validation logic (network access required; host or filtered with whitelist)
  * - Command construction and flag passing
  * - File injection via the files option
  */
@@ -33,7 +33,7 @@ describe("Integration: Agent Runtime", () => {
         code: "Write hello world",
         runtime: "agent",
       })
-    ).rejects.toThrow('Agent runtime requires network mode "filtered"');
+    ).rejects.toThrow("Agent runtime requires network access.");
   }, 30_000);
 
   test("Agent runtime rejects filtered network without whitelist", async () => {

--- a/apps/cli/tests/integration/cmd.test.ts
+++ b/apps/cli/tests/integration/cmd.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test";
+import { DockerIsol8 } from "@isol8/core";
+import { hasDocker } from "./setup";
+
+describe("Integration: cmd execution", () => {
+  if (!hasDocker) {
+    test.skip("Docker not available", () => {});
+    return;
+  }
+
+  const engine = new DockerIsol8({
+    mode: "ephemeral",
+    network: "none",
+    memoryLimit: "128m",
+  });
+
+  test("cmd runs bash regardless of runtime=python", async () => {
+    const result = await engine.execute({
+      cmd: "echo hello-from-cmd",
+      runtime: "python",
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("hello-from-cmd");
+  }, 30_000);
+
+  test("cmd runs bash regardless of runtime=node", async () => {
+    const result = await engine.execute({
+      cmd: "echo hello-from-cmd",
+      runtime: "node",
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("hello-from-cmd");
+  }, 30_000);
+
+  test("cmd runs bash regardless of runtime=bun", async () => {
+    const result = await engine.execute({
+      cmd: "echo hello-from-cmd",
+      runtime: "bun",
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("hello-from-cmd");
+  }, 30_000);
+
+  test("cmd runs bash regardless of runtime=deno", async () => {
+    const result = await engine.execute({
+      cmd: "echo hello-from-cmd",
+      runtime: "deno",
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("hello-from-cmd");
+  }, 30_000);
+
+  test("cmd runs bash regardless of runtime=bash", async () => {
+    const result = await engine.execute({
+      cmd: "echo hello-from-cmd",
+      runtime: "bash",
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("hello-from-cmd");
+  }, 30_000);
+
+  test("cmd supports multi-step shell pipeline", async () => {
+    const result = await engine.execute({
+      cmd: "echo 'hello world' | tr '[:lower:]' '[:upper:]'",
+      runtime: "python",
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("HELLO WORLD");
+  }, 30_000);
+
+  test("cmd non-zero exit code is preserved", async () => {
+    const result = await engine.execute({
+      cmd: "exit 42",
+      runtime: "bash",
+    });
+    expect(result.exitCode).toBe(42);
+  }, 30_000);
+
+  test("cmd with env vars", async () => {
+    const result = await engine.execute({
+      cmd: "echo $MY_VAR",
+      runtime: "python",
+      env: { MY_VAR: "from-env" },
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("from-env");
+  }, 30_000);
+});

--- a/apps/docs/agent-in-a-box.mdx
+++ b/apps/docs/agent-in-a-box.mdx
@@ -96,23 +96,51 @@ pi then runs its own tool-call loop inside the container. It can read, write, an
 
 ## Networking requirement
 
-The agent runtime **requires** `network: "filtered"` with at least one whitelist entry. Passing `network: "none"` throws:
+The agent runtime **requires** network access — the AI coding agent must reach its LLM provider API. `network: "none"` throws:
 
 ```
-Error: agent runtime requires network "filtered" with at least one whitelist entry.
-The agent needs access to an LLM API endpoint (e.g. "^api\\.anthropic\\.com$").
+Error: Agent runtime requires network access.
+The AI coding agent needs to reach its LLM provider API.
+Use --net host, or --net filtered --allow "api.anthropic.com" (or your provider's domain).
 ```
 
-```typescript
-// Correct
-const engine = new DockerIsol8({
-  network: "filtered",
-  networkFilter: {
-    whitelist: ["^api\\.anthropic\\.com$"],
-    blacklist: ["^169\\.254\\."],
-  },
-});
-```
+Two valid network modes for the agent runtime:
+
+| Mode | When to use |
+|:---|:---|
+| `"filtered"` | Recommended. Restricts outbound traffic to an explicit allowlist of LLM API hostnames. |
+| `"host"` | Full host network access. Use in trusted environments where you control what the agent calls. |
+
+<Tabs>
+  <Tab title="filtered (recommended)">
+    ```typescript
+    const engine = new DockerIsol8({
+      network: "filtered",
+      networkFilter: {
+        whitelist: ["^api\\.anthropic\\.com$"],
+        blacklist: ["^169\\.254\\."],
+      },
+    });
+    ```
+
+    `"filtered"` requires at least one whitelist entry — an empty whitelist throws:
+
+    ```
+    Error: Agent runtime requires at least one network whitelist entry.
+    ```
+  </Tab>
+  <Tab title="host">
+    ```typescript
+    const engine = new DockerIsol8({
+      network: "host",
+    });
+    ```
+
+    <Warning>
+      `"host"` gives the agent full access to your host network. Use only in trusted, controlled environments. Prefer `"filtered"` with an explicit whitelist whenever possible.
+    </Warning>
+  </Tab>
+</Tabs>
 
 ## Sandbox system prompt
 
@@ -371,6 +399,30 @@ for await (const event of engine.executeStream({
 }
 ```
 
+Each event carries an optional `phase` field (`"setup"` or `"code"`) so you can distinguish setup-script output from agent output:
+
+```typescript
+for await (const event of engine.executeStream({
+  runtime: "agent",
+  setupScript: "git clone https://$GITHUB_TOKEN@github.com/my-org/repo.git /sandbox/repo",
+  code: "Fix the type errors in src/parser.ts",
+  agentFlags: "--model anthropic/claude-sonnet-4-5",
+})) {
+  if (event.phase === "setup") {
+    // output from the setupScript (clone, config, etc.)
+    process.stderr.write(`[setup] ${event.data}`);
+  } else if (event.type === "stdout") {
+    process.stdout.write(event.data);
+  } else if (event.type === "exit") {
+    console.log(`\nAgent exited: ${event.data}`);
+  }
+}
+```
+
+<Note>
+  If the `setupScript` exits non-zero, the stream yields a `{ type: "error", phase: "setup" }` event followed by an `exit` event, and the agent never starts. Filter on `phase` to surface setup failures separately from agent failures.
+</Note>
+
 ## Default resource limits
 
 The agent runtime spawns subprocesses for tool calls (`bash`, package installs, git operations). The default `pidsLimit` of `64` is often too low — **explicitly set `pidsLimit: 200`** to avoid process limit errors:
@@ -418,7 +470,7 @@ const engine = new DockerIsol8({
 
 ## Troubleshooting
 
-**`Error: agent runtime requires network "filtered"`** — Switch to `network: "filtered"` and add an LLM API endpoint to the whitelist.
+**`Error: Agent runtime requires network access`** — Switch to `network: "filtered"` with at least one whitelist entry, or `network: "host"`. `network: "none"` is not supported for the agent runtime.
 
 **Agent exits non-zero** — Check `result.stderr`. Common causes: missing API key, endpoint not in whitelist, `timeoutMs` too short.
 
@@ -430,7 +482,7 @@ const engine = new DockerIsol8({
 
 <CardGroup cols={2}>
   <Card title="One-shot coding agents" icon="wand-magic-sparkles" href="/guides/one-shot-coding-agents">
-    End-to-end blueprint: clone repo, implement, lint, test, create PR — using the agent runtime.
+    Architecture and pipeline: clone repo, implement, verify, fix, and open a PR — with no human in the loop.
   </Card>
   <Card title="Setup scripts" icon="scroll" href="/setup-scripts">
     Full reference for setupScript: image-level vs request-level, execution order, error handling.

--- a/apps/docs/agent-in-a-box.mdx
+++ b/apps/docs/agent-in-a-box.mdx
@@ -78,12 +78,21 @@ When `runtime: "agent"` is used, isol8 runs:
 pi --no-session --append-system-prompt '<sandbox context>' [agentFlags] -p '<code>'
 ```
 
-- `--no-session` — disables session persistence (ephemeral, non-interactive)
+- `--no-session` — disables session persistence (ephemeral, non-interactive). This is always set by isol8; you do not need to include it in `agentFlags`.
 - `--append-system-prompt` — automatically injected by isol8 to inform pi of sandbox constraints
 - `agentFlags` — extra pi flags you supply (model, thinking level, tool restrictions)
 - `-p '<code>'` — your prompt, shell-quoted
 
 pi then runs its own tool-call loop inside the container. It can read, write, and edit files under `/sandbox`, and run arbitrary bash commands — all within the sandbox's resource and network limits.
+
+<Note>
+  The `isol8:agent` Docker image (which provides `bun`, `pi`, and `gh`) is built automatically when you run `isol8 setup` or when `DockerIsol8` first uses the agent runtime. If you need to build it manually — for example in an offline environment — run:
+
+  ```bash
+  docker build --target agent -t isol8:agent \
+    node_modules/@isol8/core/dist/docker/
+  ```
+</Note>
 
 ## Networking requirement
 
@@ -364,11 +373,19 @@ for await (const event of engine.executeStream({
 
 ## Default resource limits
 
-The agent runtime applies higher defaults than other runtimes since pi spawns subprocesses for tool calls:
+The agent runtime spawns subprocesses for tool calls (`bash`, package installs, git operations). The default `pidsLimit` of `64` is often too low — **explicitly set `pidsLimit: 200`** to avoid process limit errors:
 
-| Option | Agent default | Other runtimes |
+```typescript
+const engine = new DockerIsol8({
+  network: "filtered",
+  networkFilter: { whitelist: ["^api\\.anthropic\\.com$"], blacklist: [] },
+  pidsLimit: 200, // required — the default of 64 is too low for agent workloads
+});
+```
+
+| Option | Recommended for agent | Default (all runtimes) |
 |:---|:---|:---|
-| `pidsLimit` | `200` | `64` |
+| `pidsLimit` | `200` (set explicitly) | `64` |
 | `sandboxSize` | `2g` | `512m` |
 
 ## Retrieving output files
@@ -405,7 +422,7 @@ const engine = new DockerIsol8({
 
 **Agent exits non-zero** — Check `result.stderr`. Common causes: missing API key, endpoint not in whitelist, `timeoutMs` too short.
 
-**Agent can't reach the LLM API** — Verify the whitelist pattern is anchored (`^api\\.anthropic\\.com$`). A missing `^` or `$` won't match as expected.
+**Agent can't reach the LLM API** — Verify the whitelist pattern. Patterns are matched as extended regular expressions using `grep -E` (substring match, not full-string). Without anchors, a pattern like `anthropic\\.com` would also match `evil-anthropic.com.attacker.net`. Use `^` and `$` anchors for precise matching: `^api\\.anthropic\\.com$`.
 
 **Files not in result** — Add `outputPaths` or call `getFile()` after the run. In ephemeral mode, container state is discarded on exit.
 

--- a/apps/docs/execution.mdx
+++ b/apps/docs/execution.mdx
@@ -336,6 +336,34 @@ Real-time output is essential for long-running tasks or LLM code generation.
   When using `RemoteIsol8`, `executeStream()` automatically selects the best available transport: WebSocket (`/execute/ws`) with automatic SSE (`/execute/stream`) fallback. See the [WebSocket endpoint reference](/server/get-execute-ws) for protocol details.
 </Info>
 
+### StreamEvent reference
+
+Each value yielded by `executeStream` is a `StreamEvent`:
+
+| Field | Type | Description |
+|:---|:---|:---|
+| `type` | `"stdout" \| "stderr" \| "exit" \| "error"` | Event kind. `exit` carries the process exit code as a string in `data`. |
+| `data` | `string` | Payload: output text for stdout/stderr, exit code string for exit, error message for error. |
+| `phase` | `"setup" \| "code"` | Which stage produced the event. `"setup"` = from a `setupScript`; `"code"` = from the main code/command. Always set by isol8. |
+
+Use `phase` to distinguish `setupScript` output from main code output when both are present:
+
+```typescript
+for await (const event of engine.executeStream({
+  runtime: "bash",
+  setupScript: "git clone https://$GITHUB_TOKEN@github.com/my-org/repo.git /sandbox/repo",
+  code: "ls /sandbox/repo",
+})) {
+  if (event.phase === "setup") {
+    process.stderr.write(`[setup] ${event.data}`);
+  } else if (event.type === "stdout") {
+    process.stdout.write(event.data);
+  }
+}
+```
+
+If a `setupScript` exits non-zero, `executeStream` yields an `error` event then an `exit` event (both with `phase: "setup"`) and stops — no `phase: "code"` events follow. See [Setup scripts](/setup-scripts#error-handling) for full details.
+
 ## Resource Limits & Safety
 
 isol8 enforces strict limits to contain untrusted code.
@@ -409,6 +437,9 @@ isol8 run -e "print('my-secret-value')" --secret KEY=my-secret-value
   </Card>
   <Card title="Runtime reference" icon="square-terminal" href="/runtimes">
     Runtime-specific behavior, extensions, and package semantics.
+  </Card>
+  <Card title="Setup scripts" icon="scroll" href="/setup-scripts">
+    Run shell commands before execution — streaming output, phase events, and early-exit on failure.
   </Card>
   <Card title="Remote code URLs" icon="link" href="/remote-code">
     URL-based source fetching policy and integrity controls.

--- a/apps/docs/guides/one-shot-coding-agents.mdx
+++ b/apps/docs/guides/one-shot-coding-agents.mdx
@@ -135,7 +135,7 @@ const engine = new DockerIsol8({
   },
   timeoutMs: 300_000, // 5 minutes per step
   memoryLimit: "2g",
-  pidsLimit: 200,     // agent runtime spawns subprocesses; isol8 defaults this to 200 automatically
+  pidsLimit: 200,     // agent runtime spawns subprocesses; must be set explicitly (true default is 64)
   secrets: {
     // Passed as environment variables; values are automatically masked in stdout/stderr
     GITHUB_TOKEN: process.env.GITHUB_TOKEN!,
@@ -150,9 +150,67 @@ await engine.start();
   `mode: "persistent"` reuses a single container across all `execute()` calls, preserving filesystem state — just like Stripe's devboxes persist across agent steps.
 </Note>
 
+<Tip>
+  **Persistent vs. ephemeral:** Use `mode: "persistent"` when you need multiple `execute()` calls to share filesystem state (the multi-step blueprint pattern above). For truly fire-and-forget one-shot tasks where a single agent call does all the work, `mode: "ephemeral"` is simpler — no `start()`/`stop()` lifecycle to manage, and stale containers can't accumulate if the process crashes. See the [simple one-shot pattern](#simple-one-shot-pattern) below.
+</Tip>
+
 <Note>
   The agent runtime **requires** `network: "filtered"` with at least one whitelist entry. Passing `network: "none"` or an empty whitelist throws immediately. Pass your LLM provider's domain (e.g. `^api\\.anthropic\\.com$`) in the whitelist.
 </Note>
+
+## Simple one-shot pattern
+
+If you don't need the multi-step lint/test/iterate blueprint, you can skip the persistent engine entirely. A single `executeStream()` call with a comprehensive prompt and a `setupScript` that clones the repo is often all you need:
+
+```typescript
+import { DockerIsol8 } from "@isol8/core";
+
+const engine = new DockerIsol8({
+  network: "filtered",
+  networkFilter: {
+    whitelist: ["^api\\.anthropic\\.com$", "^github\\.com$", "^api\\.github\\.com$"],
+    blacklist: ["^169\\.254\\."],
+  },
+  memoryLimit: "2g",
+  pidsLimit: 200,
+  secrets: {
+    GITHUB_TOKEN: process.env.GITHUB_TOKEN!,
+    ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY!,
+  },
+});
+
+await engine.start();
+
+for await (const event of engine.executeStream({
+  runtime: "agent",
+  setupScript: `
+    git clone https://$GITHUB_TOKEN@github.com/my-org/my-repo.git /sandbox/repo
+    cd /sandbox/repo
+    git checkout -b agent/fix-issue-42 origin/main
+    cat > /sandbox/repo/AGENTS.md << 'EOF'
+# Project rules
+- Follow existing code style
+- Write tests for new functions
+- Do not modify the public API surface
+EOF
+  `,
+  code: `Fix the type error in src/utils/parser.ts described in issue #42.
+Lint, run tests, then commit the fix and create a PR targeting main with a clear description.`,
+  agentFlags: "--model anthropic/claude-sonnet-4-5 --thinking low",
+  workdir: "/sandbox/repo",
+  timeoutMs: 600_000,
+})) {
+  if (event.type === "stdout") process.stdout.write(event.data);
+  if (event.type === "stderr") process.stderr.write(event.data);
+  if (event.type === "exit") console.log(`\nDone (exit ${event.data})`);
+}
+
+await engine.stop();
+```
+
+<Tip>
+  In this pattern the agent is responsible for linting, testing, committing, and opening the PR — all inside the prompt. The `setupScript` handles repo setup before pi starts. Use the multi-step blueprint (Steps 3–6) when you need deterministic control over each phase or want to loop on test failures programmatically.
+</Tip>
 
 ## Step 3: Hydrate context (clone repo, inject rules)
 
@@ -182,12 +240,17 @@ EOF
   `,
   code: task,
   agentFlags: "--model anthropic/claude-sonnet-4-5 --thinking low",
+  workdir: "/sandbox/repo", // pi starts directly in the repo — no need to cd in the prompt
   timeoutMs: 300_000,
 });
 ```
 
 <Tip>
-  `setupScript` runs as bash before pi receives the prompt. It is subject to the same `timeoutMs` as the overall request. A non-zero exit aborts the execution immediately — use it to validate that required secrets are present.
+  `setupScript` runs as bash before pi receives the prompt. It is subject to the same `timeoutMs` as the overall request. A non-zero exit aborts the execution immediately — use it to validate that required secrets are present. The setup script always runs from `/sandbox` regardless of `workdir` — use explicit `cd` inside the script if you need a different directory.
+</Tip>
+
+<Tip>
+  Set `workdir: "/sandbox/repo"` on every agent `ExecutionRequest` after cloning the repo. `workdir` sets the working directory for pi's process (the main code exec) — pi will start in `/sandbox/repo` rather than the default `/sandbox`, so `AGENTS.md` is auto-loaded and relative tool calls resolve correctly. It does not affect `setupScript`, which always runs from `/sandbox`.
 </Tip>
 
 For setup that never changes between runs (git identity, tool config, registry authentication), bake it into the custom image using `prebuiltImages[].setupScript` so it runs on every execution without adding per-request latency. The per-request `setupScript` is then only the parts specific to each task — cloning the right repo, checking out the right branch, writing the task's rules:
@@ -218,6 +281,7 @@ async function agentImplement(task: string, setupScript?: string): Promise<Execu
     setupScript,
     code: task,
     agentFlags: "--model anthropic/claude-sonnet-4-5 --thinking low",
+    workdir: "/sandbox/repo", // pi starts in the repo root
     timeoutMs: 300_000,
     // Do NOT pass ANTHROPIC_API_KEY here — it is already available
     // via `secrets` in the engine config, and secrets are masked in output.
@@ -440,6 +504,7 @@ for await (const event of engine.executeStream({
   runtime: "agent",
   code: "Fix the type error in src/utils/parser.ts",
   agentFlags: "--model anthropic/claude-sonnet-4-5",
+  workdir: "/sandbox/repo",
 })) {
   switch (event.type) {
     case "stdout":

--- a/apps/docs/guides/one-shot-coding-agents.mdx
+++ b/apps/docs/guides/one-shot-coding-agents.mdx
@@ -1,589 +1,445 @@
 ---
 title: "One-shot coding agents"
-description: "Build unattended, one-shot coding agents — like Stripe's Minions — using isol8 custom images as isolated developer environments."
+description: "Build your own Stripe Minions — unattended coding agents that clone a repo, implement a task, verify the result, and open a PR — with no human in the loop."
 icon: "wand-magic-sparkles"
 ---
 
-Stripe's [Minions](https://stripe.dev/blog/minions-stripes-one-shot-end-to-end-coding-agents) are unattended coding agents that one-shot tasks end to end: a developer kicks one off, and it produces a complete pull request with no human code — only human review. Over 1,300 PRs merge at Stripe each week this way.
+Stripe's [Minions](https://stripe.dev/blog/minions-stripes-one-shot-end-to-end-coding-agents) are unattended coding agents that one-shot tasks end to end: a developer kicks one off, and it produces a complete pull request with no human in the loop. Over 1,300 PRs merge at Stripe each week this way.
 
-The architecture behind Minions has three pillars:
+This guide shows you how to build the same thing with isol8 — the architecture, each pipeline stage, and the patterns that make one-shot agents reliable.
 
-1. **Isolated, pre-warmed developer environments** — each agent run gets its own sandbox with tools, repos, and dependencies ready to go.
-2. **A blueprint-driven agent loop** — deterministic steps (lint, test, push) interleaved with agentic LLM steps (implement, fix failures).
-3. **Context hydration** — rule files, MCP tools, and documentation injected before the agent starts.
+## Architecture
 
-isol8 gives you pillar 1 out of the box, and the building blocks to wire up pillars 2 and 3. This guide walks through the full setup using **custom images** as your pre-warmed devboxes and the **`agent` runtime** as your agentic step.
+A one-shot coding agent system has three layers: a **client** that submits tasks, an **orchestrator** that sequences steps, and an **isol8 container** where all code and agent work happens.
 
-## Architecture overview
+The client can be anything — a GitHub bot reacting to issue labels, a Slack bot responding to commands, a web UI with a task form, or a CLI script. It simply sends a task description to the orchestrator and optionally consumes progress events.
 
-{/* prettier-ignore */}
 ```mermaid
 flowchart TD
-  A["Task input (Slack, ticket, CLI)"] --> B["Orchestrator"]
-  B --> C["Build / select custom image"]
-  C --> D["isol8 persistent session"]
-  D --> E["Setup: clone repo, hydrate context"]
-  E --> F["Agent step: runtime='agent', code=prompt"]
-  F --> G{{"Lint locally"}}
-  G -->|Fail| F
-  G -->|Pass| H["Push + run CI"]
-  H --> I{{"CI passes?"}}
-  I -->|Fail round 1| J["Agent step: fix CI failures"]
-  J --> H
-  I -->|Pass or round 2| K["Create PR for human review"]
+  Client["Client — GitHub bot / Slack bot / Web UI / CLI"]
+  Orchestrator["Orchestrator — sequences steps, handles retries"]
+  Container["isol8 container — persistent mode, shared filesystem"]
+
+  Client -->|"submit task"| Orchestrator
+  Orchestrator -->|"execute steps"| Container
+  Container -->|"stdout / stderr / exit code"| Orchestrator
+  Orchestrator -->|"progress events + PR link"| Client
 ```
 
-## Step 1: Build a custom devbox image
+The orchestrator is the core of the system. It creates a single persistent isol8 container and runs a pipeline of steps inside it:
 
-Stripe pre-warms EC2 "devboxes" with repos, caches, and tools. With isol8, **custom images** serve the same purpose — a Docker image with your project's dependencies baked in so every agent run starts instantly.
+```mermaid
+flowchart TD
+  Setup["Setup — clone repo, install deps"]
+  Implement["Implement — agent writes code"]
+  Verify["Verify — lint + build"]
+  Fix["Fix loop — agent fixes errors"]
+  Ship["Ship — commit + open PR"]
 
-### CLI approach
-
-```bash
-# Build a Python data-science devbox
-isol8 build \
-  --base python \
-  --install numpy pandas scikit-learn pytest black ruff \
-  --setup "git config --global user.name 'agent' && git config --global user.email 'agent@ci'" \
-  --tag my-org/python-devbox:latest
-
-# Build a Node.js fullstack devbox
-isol8 build \
-  --base node \
-  --install typescript eslint prettier jest \
-  --tag my-org/node-devbox:latest
+  Setup --> Implement --> Verify --> Fix --> Ship
+  Fix -->|"still failing"| Fix
 ```
 
-The `--setup` flag bakes a shell script into the image that runs before every execution — use it for git config, SSH keys, tool setup, or anything your agent needs before it starts coding.
+Every step runs inside the **same container**. The filesystem state built up during setup (`/sandbox/repo`) persists through implement, verify, fix, and ship.
 
-### Config approach (recommended for servers)
+## The container: one persistent session per task
 
-Define `prebuiltImages` in `isol8.config.json` so images are built automatically when the server starts or when you run `isol8 setup`:
-
-```json
-{
-  "$schema": "https://raw.githubusercontent.com/Illusion47586/isol8/main/packages/core/schema/isol8.config.schema.json",
-  "maxConcurrent": 20,
-  "prebuiltImages": [
-    {
-      "tag": "my-org/python-devbox:latest",
-      "runtime": "python",
-      "installPackages": ["numpy", "pandas", "scikit-learn", "pytest", "black", "ruff"],
-      "setupScript": "git config --global user.name 'agent' && git config --global user.email 'agent@ci'"
-    },
-    {
-      "tag": "my-org/node-devbox:latest",
-      "runtime": "node",
-      "installPackages": ["typescript", "eslint", "prettier", "jest"]
-    }
-  ],
-  "defaults": {
-    "timeoutMs": 300000,
-    "memoryLimit": "2g",
-    "network": "filtered"
-  },
-  "network": {
-    "whitelist": [
-      "^api\\.anthropic\\.com$",
-      "^github\\.com$",
-      "^api\\.github\\.com$",
-      "^registry\\.npmjs\\.org$",
-      "^pypi\\.org$"
-    ],
-    "blacklist": ["^169\\.254\\."]
-  },
-  "cleanup": {
-    "autoPrune": true,
-    "maxContainerAgeMs": 7200000
-  },
-  "poolStrategy": "fast",
-  "poolSize": { "clean": 5, "dirty": 5 }
-}
-```
-
-Then build everything:
-
-```bash
-isol8 setup
-```
-
-<Tip>
-  isol8 uses content-addressed hashing for custom images. If the packages and setup script haven't changed, `isol8 setup` skips the build entirely — making it safe to call on every deploy.
-</Tip>
-
-## Step 2: Create the orchestrator
-
-The orchestrator is the "blueprint" — a TypeScript program that sequences deterministic bash steps and agentic `agent` runtime steps. Use `DockerIsol8` in persistent mode with your custom image.
+Each task gets a single `DockerIsol8` instance in `mode: "persistent"`. All steps share the container's filesystem.
 
 ```typescript
-import { DockerIsol8 } from "@isol8/core";
-import type { ExecutionResult } from "@isol8/core";
-
 const engine = new DockerIsol8({
   mode: "persistent",
-  image: "my-org/python-devbox:latest",
-  network: "filtered",
-  networkFilter: {
-    // LLM API access + VCS + package registries
-    whitelist: [
-      "^api\\.anthropic\\.com$",
-      "^github\\.com$",
-      "^api\\.github\\.com$",
-      "^pypi\\.org$",
-    ],
-    blacklist: ["^169\\.254\\."],
-  },
-  timeoutMs: 300_000, // 5 minutes per step
-  memoryLimit: "2g",
-  pidsLimit: 200,     // agent runtime spawns subprocesses; must be set explicitly (true default is 64)
+  network: "host",
+  timeoutMs: 1_800_000,   // 30-minute hard ceiling for the whole run
+  memoryLimit: "4g",
+  cpuLimit: 2,
+  pidsLimit: 200,          // agent spawns subprocesses; default of 64 is too low
+  sandboxSize: "4g",
+  maxOutputSize: 10 * 1024 * 1024,
+  image: "isol8:agent",
   secrets: {
-    // Passed as environment variables; values are automatically masked in stdout/stderr
-    GITHUB_TOKEN: process.env.GITHUB_TOKEN!,
-    ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY!,
+    GITHUB_TOKEN: githubToken,
+    ANTHROPIC_API_KEY: anthropicKey,
   },
 });
 
 await engine.start();
+// ... run all steps ...
+await engine.stop(); // always in a finally block
 ```
 
 <Note>
-  `mode: "persistent"` reuses a single container across all `execute()` calls, preserving filesystem state — just like Stripe's devboxes persist across agent steps.
+  `network: "host"` is used here because the agent needs to reach GitHub, the LLM provider API, and package registries simultaneously. If you know your exact set of hostnames, `network: "filtered"` with an explicit whitelist is more secure. See [Security considerations](#security-considerations).
 </Note>
 
-<Tip>
-  **Persistent vs. ephemeral:** Use `mode: "persistent"` when you need multiple `execute()` calls to share filesystem state (the multi-step blueprint pattern above). For truly fire-and-forget one-shot tasks where a single agent call does all the work, `mode: "ephemeral"` is simpler — no `start()`/`stop()` lifecycle to manage, and stale containers can't accumulate if the process crashes. See the [simple one-shot pattern](#simple-one-shot-pattern) below.
-</Tip>
+## Step 1: Setup — clone before the agent starts
 
-<Note>
-  The agent runtime **requires** `network: "filtered"` with at least one whitelist entry. Passing `network: "none"` or an empty whitelist throws immediately. Pass your LLM provider's domain (e.g. `^api\\.anthropic\\.com$`) in the whitelist.
-</Note>
-
-## Simple one-shot pattern
-
-If you don't need the multi-step lint/test/iterate blueprint, you can skip the persistent engine entirely. A single `executeStream()` call with a comprehensive prompt and a `setupScript` that clones the repo is often all you need:
+Before the agent receives any prompt, a `setupScript` clones the repo and checks out a branch. Setup scripts run as bash inside the container and complete before the main execution begins.
 
 ```typescript
-import { DockerIsol8 } from "@isol8/core";
-
-const engine = new DockerIsol8({
-  network: "filtered",
-  networkFilter: {
-    whitelist: ["^api\\.anthropic\\.com$", "^github\\.com$", "^api\\.github\\.com$"],
-    blacklist: ["^169\\.254\\."],
-  },
-  memoryLimit: "2g",
-  pidsLimit: 200,
-  secrets: {
-    GITHUB_TOKEN: process.env.GITHUB_TOKEN!,
-    ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY!,
-  },
-});
-
-await engine.start();
-
-for await (const event of engine.executeStream({
-  runtime: "agent",
-  setupScript: `
-    git clone https://$GITHUB_TOKEN@github.com/my-org/my-repo.git /sandbox/repo
-    cd /sandbox/repo
-    git checkout -b agent/fix-issue-42 origin/main
-    cat > /sandbox/repo/AGENTS.md << 'EOF'
-# Project rules
-- Follow existing code style
-- Write tests for new functions
-- Do not modify the public API surface
-EOF
-  `,
-  code: `Fix the type error in src/utils/parser.ts described in issue #42.
-Lint, run tests, then commit the fix and create a PR targeting main with a clear description.`,
-  agentFlags: "--model anthropic/claude-sonnet-4-5 --thinking low",
-  workdir: "/sandbox/repo",
-  timeoutMs: 600_000,
-})) {
-  if (event.type === "stdout") process.stdout.write(event.data);
-  if (event.type === "stderr") process.stderr.write(event.data);
-  if (event.type === "exit") console.log(`\nDone (exit ${event.data})`);
+function buildSetupScript(repo: string, branch: string): string {
+  return `
+set -e
+git config --global user.email "agent@ci.internal"
+git config --global user.name "Agent"
+cd /sandbox && rm -rf repo
+git clone https://x-access-token:$GITHUB_TOKEN@github.com/${repo}.git repo 2>&1
+cd repo
+git checkout -b ${branch} || git checkout ${branch}
+npm ci
+echo "ready — branch ${branch}"`;
 }
 
-await engine.stop();
+await engine.execute({
+  runtime: "agent",
+  setupScript: buildSetupScript("my-org/my-repo", "agent/fix-auth"),
+  code: 'echo "[setup] done"',
+  timeoutMs: 300_000,
+  workdir: "/sandbox/repo",
+});
 ```
 
-<Tip>
-  In this pattern the agent is responsible for linting, testing, committing, and opening the PR — all inside the prompt. The `setupScript` handles repo setup before pi starts. Use the multi-step blueprint (Steps 3–6) when you need deterministic control over each phase or want to loop on test failures programmatically.
-</Tip>
+<Warning>
+  **`git checkout -b` on retry:** With `set -e`, `git checkout -b` exits non-zero if the branch already exists (e.g. on a retry). The `|| git checkout ${branch}` fallback is load-bearing — always include it.
+</Warning>
 
-## Step 3: Hydrate context (clone repo, inject rules)
+## Step 2: Implement — the agent gets the task
 
-Before the agent starts coding, set up the workspace. Use `setupScript` on the agent execution itself — it runs as bash inside the container before pi receives the prompt, so the repo, rules, and any config files are all in place when the agent starts.
+The implement step passes a prompt to the agent runtime. The agent reads files, writes code, and runs tools — all inside the sandbox.
+
+A naive approach passes the raw task description directly:
 
 ```typescript
-const task = `Fix the type error in src/utils/parser.ts described in issue #42.
-Follow existing code style, write tests for any new functions, and do not modify the public API surface.`;
-
-const result = await engine.execute({
+await engine.execute({
   runtime: "agent",
-  setupScript: `
-    # Clone the repo and create an agent branch
-    git clone https://$GITHUB_TOKEN@github.com/my-org/my-repo.git /sandbox/repo
-    cd /sandbox/repo
-    git checkout -b agent/fix-issue-42 origin/main
+  code: `You are working in /sandbox/repo on branch \`${branch}\` of ${repo}.
 
-    # Write project rules — pi auto-loads AGENTS.md from its working directory
-    cat > /sandbox/repo/AGENTS.md << 'EOF'
-# Project rules
-- Follow existing code style — no reformatting unrelated files
-- No new runtime dependencies without approval
-- All new functions must have JSDoc comments
-- Tests live in tests/ — use the existing test runner (pytest)
-- Do not modify the public API surface
-EOF
-  `,
-  code: task,
-  agentFlags: "--model anthropic/claude-sonnet-4-5 --thinking low",
-  workdir: "/sandbox/repo", // pi starts directly in the repo — no need to cd in the prompt
+Implement the following task — read the repo structure first, make all necessary code
+changes, run \`npm install\` if node_modules is missing. Do NOT commit anything.
+
+Task:
+${task}`,
+  agentFlags: "--model anthropic/claude-sonnet-4-5 --no-session",
+  timeoutMs: 1_200_000,
+  workdir: "/sandbox/repo",
+});
+```
+
+This works for simple tasks but is fragile. The isol8 agent has no way to ask follow-up questions — the prompt is the complete specification.
+
+<Note>
+  **In practice, the orchestrator should act as a master agent.** Gather context before handing off: read relevant files, pull issue details, summarize related PRs, fetch coding guidelines. Construct a self-sufficient prompt that gives the agent everything it needs without clarification.
+</Note>
+
+A better implement step looks like this:
+
+```typescript
+// The orchestrator gathers context before handing off
+const relevantFiles = await readFilesFromGitHub(repo, issue.changedPaths);
+const relatedIssues = await searchIssues(repo, issue.title);
+const codeStyle = await readFile(repo, "CONTRIBUTING.md");
+
+const prompt = `
+You are working in /sandbox/repo. The codebase uses TypeScript strict mode.
+
+## Task
+${issue.body}
+
+## Files most likely to need changes
+${relevantFiles.map(f => `### ${f.path}\n\`\`\`\n${f.content}\n\`\`\``).join("\n\n")}
+
+## Code style rules
+${codeStyle}
+
+## Related context
+${relatedIssues.map(i => `- #${i.number}: ${i.title}`).join("\n")}
+
+Make all necessary changes. Do NOT commit.
+`;
+
+await engine.execute({
+  runtime: "agent",
+  code: prompt,
+  agentFlags: "--model anthropic/claude-sonnet-4-5 --no-session",
+  timeoutMs: 1_200_000,
+  workdir: "/sandbox/repo",
+});
+```
+
+## Step 3: Verify — lint and build
+
+After the agent implements, deterministic shell steps verify the result. Lint and build are the only steps allowed to fail — their output is collected and fed into a fix loop, not treated as a hard error.
+
+```typescript
+const lintResult = await engine.execute({
+  runtime: "agent",
+  cmd: "npm run lint 2>&1",
+  workdir: "/sandbox/repo",
+  timeoutMs: 120_000,
+});
+
+const buildResult = await engine.execute({
+  runtime: "agent",
+  cmd: "npm run build 2>&1",
+  workdir: "/sandbox/repo",
   timeoutMs: 300_000,
 });
 ```
 
-<Tip>
-  `setupScript` runs as bash before pi receives the prompt. It is subject to the same `timeoutMs` as the overall request. A non-zero exit aborts the execution immediately — use it to validate that required secrets are present. The setup script always runs from `/sandbox` regardless of `workdir` — use explicit `cd` inside the script if you need a different directory.
-</Tip>
-
-<Tip>
-  Set `workdir: "/sandbox/repo"` on every agent `ExecutionRequest` after cloning the repo. `workdir` sets the working directory for pi's process (the main code exec) — pi will start in `/sandbox/repo` rather than the default `/sandbox`, so `AGENTS.md` is auto-loaded and relative tool calls resolve correctly. It does not affect `setupScript`, which always runs from `/sandbox`.
-</Tip>
-
-For setup that never changes between runs (git identity, tool config, registry authentication), bake it into the custom image using `prebuiltImages[].setupScript` so it runs on every execution without adding per-request latency. The per-request `setupScript` is then only the parts specific to each task — cloning the right repo, checking out the right branch, writing the task's rules:
-
-```json isol8.config.json
-{
-  "prebuiltImages": [
-    {
-      "tag": "my-org/python-devbox:latest",
-      "runtime": "python",
-      "installPackages": ["numpy", "pandas", "scikit-learn", "pytest", "black", "ruff"],
-      "setupScript": "git config --global user.name 'isol8-agent' && git config --global user.email 'agent@ci.internal' && git config --global core.autocrlf false"
-    }
-  ]
-}
+```mermaid
+flowchart TD
+  Lint["Lint"] --> LintCheck{{"Pass?"}}
+  Build["Build"] --> BuildCheck{{"Pass?"}}
+  LintCheck -->|Yes| BuildCheck
+  LintCheck -->|No| CollectErrors["Collect errors"]
+  BuildCheck -->|No| CollectErrors
+  BuildCheck -->|Yes| Ship["Ship — commit + PR"]
+  CollectErrors --> FixLoop["Fix loop"]
 ```
 
-## Step 4: Run the agent step
+## Step 4: Fix loop — automated retry
 
-Use `runtime: "agent"` to run the pi coding agent inside the sandbox. The `code` field is the natural-language prompt — pi handles the full LLM loop, tool calls (`read`, `write`, `edit`, `bash`), and file edits autonomously inside the container.
-
-The `setupScript` from Step 3 already clones the repo and writes `AGENTS.md` before pi starts. Here the `agentImplement` helper is a thin wrapper that passes a task prompt to the same pattern:
+If lint or build fails, the fix loop runs the agent again with the error output, then re-verifies. Two rounds is the practical ceiling — after that, hand off to humans.
 
 ```typescript
-async function agentImplement(task: string, setupScript?: string): Promise<ExecutionResult> {
-  return engine.execute({
+const maxFixRounds = 2;
+
+for (let round = 1; round <= maxFixRounds; round++) {
+  await engine.execute({
     runtime: "agent",
-    setupScript,
-    code: task,
-    agentFlags: "--model anthropic/claude-sonnet-4-5 --thinking low",
-    workdir: "/sandbox/repo", // pi starts in the repo root
-    timeoutMs: 300_000,
-    // Do NOT pass ANTHROPIC_API_KEY here — it is already available
-    // via `secrets` in the engine config, and secrets are masked in output.
-    // Using per-request env bypasses masking.
+    code: `You are working in /sandbox/repo. Fix all of the following errors.
+Do NOT commit anything.
+
+${lintErrors}
+${buildErrors}`,
+    agentFlags: "--model anthropic/claude-sonnet-4-5 --no-session",
+    timeoutMs: 900_000,
+    workdir: "/sandbox/repo",
   });
-}
-```
 
-<Tip>
-  Always pass LLM API keys via `secrets` in the engine config, not in per-request `env`. Keys in `secrets` are automatically redacted from stdout/stderr; keys in `env` are not.
-</Tip>
-
-isol8 automatically appends a sandbox-awareness system prompt to pi's default prompt via `--append-system-prompt`. You do not need to tell pi it is in a container.
-
-The `agentFlags` field passes extra arguments to the `pi` CLI before `-p`. Useful flags:
-
-| Flag | Description |
-|:---|:---|
-| `--model <provider/id>` | LLM to use (e.g. `anthropic/claude-sonnet-4-5`, `openai/gpt-4o`) |
-| `--thinking <level>` | Thinking budget: `off`, `minimal`, `low`, `medium`, `high`, `xhigh` |
-| `--tools <list>` | Limit built-in tools (default: `read,bash,edit,write`) |
-| `--no-tools` | Disable all built-in tools (prompt-only mode) |
-| `--no-skills` | Disable auto-loading of skill files |
-| `--no-extensions` | Disable auto-loading of extensions |
-
-<Warning>
-  The agent runtime enforces `network: "filtered"` at both `execute()` and `executeStream()` call sites. Passing `network: "none"` or `network: "host"` — or an empty whitelist — throws before any container work begins.
-</Warning>
-
-## Step 5: Deterministic lint and test steps
-
-After the agent finishes coding, run linters and tests deterministically — no LLM involvement. This matches Stripe's blueprint pattern of interleaving deterministic nodes with agentic nodes.
-
-```typescript
-async function runLint(): Promise<ExecutionResult> {
-  return engine.execute({
-    runtime: "bash",
-    code: `
-      cd /sandbox/repo
-      npx prettier --write 'src/**/*.ts'
-      npx eslint --fix 'src/**/*.ts'
-      echo "Lint complete"
-    `,
-    timeoutMs: 60_000,
-  });
-}
-
-async function runTests(): Promise<ExecutionResult> {
-  return engine.execute({
-    runtime: "bash",
-    code: `
-      cd /sandbox/repo
-      npx jest --ci --passWithNoTests 2>&1
-    `,
+  // Re-verify after fix
+  const relint = await engine.execute({
+    runtime: "agent",
+    cmd: "npm run lint 2>&1",
+    workdir: "/sandbox/repo",
     timeoutMs: 120_000,
   });
+  const rebuild = await engine.execute({
+    runtime: "agent",
+    cmd: "npm run build 2>&1",
+    workdir: "/sandbox/repo",
+    timeoutMs: 300_000,
+  });
+
+  if (relint.exitCode === 0 && rebuild.exitCode === 0) break;
+  if (round === maxFixRounds) throw new Error("Still failing after max fix rounds");
 }
 ```
 
-## Step 6: Wire up the full blueprint
+<Tip>
+  Diminishing returns set in quickly. Two fix rounds is the practical ceiling — after that, hand off to humans rather than burning more tokens.
+</Tip>
 
-Combine all steps into a single orchestration flow. The `setupScript` handles cloning and context hydration as part of the first agent call — no separate bash step needed:
+## Step 5: Ship — commit and open a PR
 
-```typescript
-async function runMinion(task: string) {
-  const MAX_CI_ROUNDS = 2;
-
-  const setupScript = `
-    git clone https://$GITHUB_TOKEN@github.com/my-org/my-repo.git /sandbox/repo
-    cd /sandbox/repo
-    git checkout -b agent/fix-issue-42 origin/main
-
-    cat > /sandbox/repo/AGENTS.md << 'EOF'
-# Project rules
-- Follow existing code style
-- No new runtime dependencies without approval
-- All new functions must have JSDoc comments
-- Tests live in tests/ — use pytest
-EOF
-  `;
-
-  // --- Agentic: implement (runtime: "agent") with context hydration via setupScript ---
-  console.log("[1/4] Agent implementing task...");
-  const implResult = await agentImplement(task, setupScript);
-  if (implResult.exitCode !== 0) {
-    console.warn("Agent step exited non-zero:", implResult.stderr);
-  }
-
-  // --- Deterministic: lint ---
-  console.log("[2/4] Running linters...");
-  const lintResult = await runLint();
-  if (lintResult.exitCode !== 0) {
-    // Let the agent fix lint issues — repo is already in place, no setupScript needed
-    await agentImplement("Fix the lint errors:\n" + lintResult.stderr);
-    await runLint();
-  }
-
-  // --- Deterministic: test + iterate ---
-  for (let round = 1; round <= MAX_CI_ROUNDS; round++) {
-    console.log(`[3/4] Running tests (round ${round}/${MAX_CI_ROUNDS})...`);
-    const testResult = await runTests();
-
-    if (testResult.exitCode === 0) {
-      console.log("Tests passed!");
-      break;
-    }
-
-    if (round < MAX_CI_ROUNDS) {
-      // --- Agentic: fix failures ---
-      console.log("Tests failed, agent fixing...");
-      await agentImplement("Fix the failing tests. Errors:\n" + testResult.stderr);
-    } else {
-      console.log("Tests still failing after max rounds. Proceeding with PR for human review.");
-    }
-  }
-
-  // --- Deterministic: commit and push ---
-  console.log("[4/4] Committing and pushing...");
-  await engine.execute({
-    runtime: "bash",
-    code: `
-      cd /sandbox/repo
-      git add -A
-      git commit -m "fix: resolve type error in parser (closes #42)
-
-      Automated change produced by coding agent."
-      git push origin agent/fix-issue-42
-    `,
-  });
-
-  // --- Deterministic: create PR ---
-  await engine.execute({
-    runtime: "bash",
-    code: `
-      cd /sandbox/repo
-      gh pr create \
-        --title "fix: resolve type error in parser (closes #42)" \
-        --body "## Summary
-      Automated fix for issue #42.
-
-      This PR was produced by an unattended coding agent. Please review carefully.
-
-      ## Changes
-      - Fixed type error in src/utils/parser.ts
-      - Added unit tests" \
-        --base main \
-        --head agent/fix-issue-42
-    `,
-  });
-
-  await engine.stop();
-  console.log("Done! PR created for human review.");
-}
-
-// Run it
-runMinion("Fix the type error in src/utils/parser.ts described in issue #42. Follow existing code style, write tests for any new functions, do not modify the public API surface.");
-```
-
-## Scaling with the remote server
-
-For production, run isol8 as a centralized server so multiple agents can execute in parallel — the equivalent of Stripe's fleet of devboxes. Each agent gets its own persistent session.
-
-### Start the server
-
-```bash
-isol8 serve --port 3000 --key "$ISOL8_API_KEY"
-```
-
-### Connect agents via RemoteIsol8
+The commit and PR steps are also delegated to the agent. Two shell patterns matter:
 
 ```typescript
-import { RemoteIsol8 } from "@isol8/core";
-import { randomUUID } from "node:crypto";
+// Commit — write message to a file, use -F not -m (avoids interactive editor traps)
+await engine.execute({
+  runtime: "agent",
+  code: `Write a conventional commit message to /tmp/commit-msg.txt, then run:
+git add -A && git commit -F /tmp/commit-msg.txt && git push -u origin ${branch}`,
+  agentFlags: "--model anthropic/claude-sonnet-4-5 --no-session",
+  timeoutMs: 300_000,
+  workdir: "/sandbox/repo",
+});
 
-async function spawnAgent(task: string) {
-  const sessionId = `agent-${randomUUID()}`;
+// PR — write body to a file, use --body-file not --body (avoids shell escaping issues)
+const prResult = await engine.execute({
+  runtime: "agent",
+  code: `Write the PR title to /tmp/pr-title.txt and body to /tmp/pr-body.md, then run:
+gh pr create --title "$(cat /tmp/pr-title.txt)" --body-file /tmp/pr-body.md --base main --head ${branch}
+Output the resulting PR URL on its own line.`,
+  agentFlags: "--model anthropic/claude-sonnet-4-5 --no-session",
+  timeoutMs: 300_000,
+  workdir: "/sandbox/repo",
+});
 
-  const engine = new RemoteIsol8(
-    {
-      host: "http://isol8-server.internal:3000",
-      apiKey: process.env.ISOL8_API_KEY!,
-      sessionId,
+// Extract the PR URL from output
+const PR_URL_REGEX = /https:\/\/github\.com\/[^\s]+\/pull\/(\d+)/;
+const prMatch = (prResult.stdout + prResult.stderr).match(PR_URL_REGEX);
+const prUrl = prMatch?.[0];
+```
+
+## Full pipeline
+
+Putting it all together, the orchestrator function:
+
+```typescript
+async function runOneShot(task: string, repo: string, branch: string) {
+  const engine = new DockerIsol8({
+    mode: "persistent",
+    network: "host",
+    timeoutMs: 1_800_000,
+    memoryLimit: "4g",
+    cpuLimit: 2,
+    pidsLimit: 200,
+    sandboxSize: "4g",
+    image: "isol8:agent",
+    secrets: {
+      GITHUB_TOKEN: process.env.GITHUB_TOKEN!,
+      ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY!,
     },
-    {
-      mode: "persistent",
-      image: "my-org/python-devbox:latest",
-      network: "filtered",
-      networkFilter: {
-        whitelist: ["^api\\.anthropic\\.com$", "^github\\.com$", "^api\\.github\\.com$"],
-        blacklist: [],
-      },
-      timeoutMs: 300_000,
-      memoryLimit: "2g",
-      pidsLimit: 200,
-    }
-  );
+  });
 
   await engine.start();
 
-  // Run the full agent blueprint against the remote session
-  await runBlueprintAgainst(engine, task);
+  try {
+    // 1. Setup
+    await engine.execute({
+      runtime: "agent",
+      setupScript: buildSetupScript(repo, branch),
+      code: 'echo "setup complete"',
+      timeoutMs: 300_000,
+    });
 
-  await engine.stop();
+    // 2. Implement
+    await engine.execute({
+      runtime: "agent",
+      code: buildPrompt(task, repo, branch),
+      agentFlags: "--model anthropic/claude-sonnet-4-5 --no-session",
+      timeoutMs: 1_200_000,
+      workdir: "/sandbox/repo",
+    });
+
+    // 3. Verify
+    const lint = await engine.execute({
+      runtime: "agent",
+      cmd: "npm run lint 2>&1",
+      workdir: "/sandbox/repo",
+      timeoutMs: 120_000,
+    });
+    const build = await engine.execute({
+      runtime: "agent",
+      cmd: "npm run build 2>&1",
+      workdir: "/sandbox/repo",
+      timeoutMs: 300_000,
+    });
+
+    // 4. Fix loop (if needed)
+    if (lint.exitCode !== 0 || build.exitCode !== 0) {
+      await runFixLoop(engine, lint, build, branch);
+    }
+
+    // 5. Ship
+    const prUrl = await commitAndCreatePR(engine, branch);
+    return prUrl;
+  } finally {
+    await engine.stop();
+  }
 }
-
-// Spawn multiple agents in parallel
-await Promise.all([
-  spawnAgent("Fix issue #42"),
-  spawnAgent("Fix issue #43"),
-  spawnAgent("Add unit tests for auth module"),
-]);
 ```
 
-### Stream agent output in real-time
+## Streaming progress to clients
 
-Use streaming to pipe agent activity to a UI or Slack thread:
+Every step can use `executeStream()` to emit progress in real-time. The `phase` field on each `StreamEvent` distinguishes setup output from agent output:
 
 ```typescript
 for await (const event of engine.executeStream({
   runtime: "agent",
-  code: "Fix the type error in src/utils/parser.ts",
-  agentFlags: "--model anthropic/claude-sonnet-4-5",
-  workdir: "/sandbox/repo",
+  setupScript: buildSetupScript(repo, branch),
+  code: buildPrompt(task, repo, branch),
+  agentFlags: "--model anthropic/claude-sonnet-4-5 --no-session",
 })) {
-  switch (event.type) {
-    case "stdout":
-      slackThread.postUpdate(event.data);
-      break;
-    case "stderr":
-      slackThread.postWarning(event.data);
-      break;
-    case "exit":
-      slackThread.postResult(`Agent finished with exit code ${event.data}`);
-      break;
+  if (event.phase === "setup") {
+    onProgress({ step: "setup", data: event.data });
+  } else if (event.type === "stdout") {
+    onProgress({ step: "implement", data: event.data });
+  } else if (event.type === "exit") {
+    onProgress({ step: "implement", data: `exited: ${event.data}` });
   }
 }
 ```
 
-## Stripe Minions concept mapping
+How you relay these events to the client depends on your architecture — SSE, WebSockets, a message queue, or writing to a database that the client polls. The orchestrator produces `StreamEvent`s; what the client does with them is up to you.
 
-| Stripe Minions concept | isol8 equivalent |
-|:--|:--|
-| Devbox (pre-warmed EC2 instance) | Custom image with `prebuiltImages` + persistent session |
-| Devbox pool (hot and ready) | Warm container pool (`poolSize`, `poolStrategy: "fast"`) |
-| Isolated environment (no production access) | `network: "filtered"` with allowlisted hosts |
-| Blueprint (deterministic + agentic nodes) | Orchestrator mixing `runtime: "bash"` steps with `runtime: "agent"` steps |
-| Agentic node (LLM implements/fixes) | `engine.execute({ runtime: "agent", code: prompt, agentFlags: ... })` |
-| Context gathering (clone repo, gather docs) | `setupScript` on the agent execution — runs before pi receives the prompt |
-| Rule files (Cursor rules, AGENTS.md) | Written via `setupScript` or `putFile()` — pi auto-loads `AGENTS.md` from cwd |
-| Recurring devbox config (git identity, registries) | `prebuiltImages[].setupScript` — baked into the image, runs on every execution |
-| MCP tools (Toolshed) | `network: "filtered"` allowing agent to call external APIs |
-| Local lint loop (pre-push hooks) | Deterministic lint step with `runtime: "bash"` before push |
-| CI feedback loop (at most 2 rounds) | Test step looped with `MAX_CI_ROUNDS` + agent fix step |
-| Secret isolation (no prod credentials) | `secrets` option — values are automatically masked in output |
-| Parallelization (many devboxes) | Multiple `RemoteIsol8` sessions via centralized server |
+<Note>
+  If the `setupScript` exits non-zero, the stream yields a `{ type: "error", phase: "setup" }` event followed by an `exit` event, and the agent never starts. Filter on `phase` to surface setup failures separately from agent failures.
+</Note>
+
+## Concurrency and cancellation
+
+When running multiple tasks concurrently, use a job queue with bounded concurrency. Each task should get its own `AbortController` for cancellation — aborting triggers `engine.stop()` to destroy the container immediately.
+
+```typescript
+import PQueue from "p-queue";
+
+const queue = new PQueue({ concurrency: 3 });
+const controllers = new Map<string, AbortController>();
+
+function enqueueTask(taskId: string, task: string, repo: string, branch: string) {
+  const controller = new AbortController();
+  controllers.set(taskId, controller);
+
+  queue.add(async () => {
+    if (controller.signal.aborted) return;
+    await runOneShot(task, repo, branch);
+  }, { signal: controller.signal });
+}
+
+function cancelTask(taskId: string) {
+  controllers.get(taskId)?.abort();
+}
+```
+
+Inside the orchestrator, wire the abort signal to `engine.stop()`:
+
+```typescript
+const onAbort = () => engine.stop().catch(() => undefined);
+signal?.addEventListener("abort", onAbort, { once: true });
+
+try {
+  // ... all steps ...
+} finally {
+  signal?.removeEventListener("abort", onAbort);
+  await engine.stop();
+}
+```
 
 ## Security considerations
 
-Stripe isolates their devboxes from production. isol8 provides equivalent guardrails:
-
-- **Read-only root filesystem** — agents can only write to `/sandbox` and `/tmp`
-- **Non-root execution** — all code runs as `sandbox` user (uid 100)
-- **Network filtering** — allowlist only the hosts your agent needs (LLM APIs, GitHub, package registries)
-- **Secret masking** — credentials in `secrets` are automatically redacted from stdout/stderr
-- **Resource limits** — CPU, memory, PIDs, and output size caps prevent runaway agents
-- **Seccomp profiles** — strict syscall filtering applied by default
-- **Session isolation** — each agent session is a separate container with no shared state
-- **Sandbox-aware system prompt** — isol8 appends a prompt informing pi of sandbox constraints, so the agent doesn't attempt operations that will fail
+For production deployments — especially multi-tenant or untrusted-task workloads — use `network: "filtered"` with an explicit allowlist instead of `network: "host"`:
 
 ```typescript
 const engine = new DockerIsol8({
   mode: "persistent",
-  image: "my-org/node-devbox:latest",
   network: "filtered",
   networkFilter: {
     whitelist: [
-      "^api\\.anthropic\\.com$",
-      "^github\\.com$",
-      "^registry\\.npmjs\\.org$",
+      "^api\\.anthropic\\.com$",       // LLM API
+      "^github\\.com$",                // git clone + push
+      "^api\\.github\\.com$",          // gh CLI (pr create, auth)
+      "^registry\\.npmjs\\.org$",      // npm installs
     ],
-    blacklist: ["^169\\.254\\.", "^10\\.", "^172\\.(1[6-9]|2[0-9]|3[01])\\."],
+    blacklist: [
+      "^169\\.254\\.",                  // link-local (cloud metadata)
+      "^10\\.",                         // RFC 1918
+      "^172\\.(1[6-9]|2[0-9]|3[01])\\.", // RFC 1918
+    ],
   },
   secrets: {
-    GITHUB_TOKEN: process.env.GITHUB_TOKEN!,
-    ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY!,
+    GITHUB_TOKEN: githubToken,
+    ANTHROPIC_API_KEY: anthropicKey,
   },
+  memoryLimit: "4g",
   cpuLimit: 2,
-  memoryLimit: "2g",
   pidsLimit: 200,
-  maxOutputSize: 5_242_880, // 5MB
+  maxOutputSize: 10 * 1024 * 1024,
 });
 ```
 
-## Tips from the Stripe playbook
-
-1. **Shift feedback left** — run linters and fast checks inside the container before pushing to CI. This saves tokens and compute.
-2. **Limit CI rounds** — diminishing returns after 1-2 rounds. Cap iterations and hand off to humans.
-3. **Bake dependencies into images** — don't waste agent time installing packages. Use `prebuiltImages` to pre-install everything.
-4. **Scope context tightly** — inject only relevant rule files and documentation as `AGENTS.md`. Don't dump your entire codebase.
-5. **Deterministic where possible** — lint, format, test, commit, and push are deterministic steps. Don't let the LLM do what a shell script can do better.
-6. **Use `secrets` for API keys** — never pass LLM credentials via per-request `env`; use `secrets` so they are masked in output.
-7. **Use setup scripts for context hydration** — clone the repo, write `AGENTS.md`, and configure tools via `setupScript` on the agent execution. Use `prebuiltImages[].setupScript` for setup that never changes (git identity, registry auth); use per-request `setupScript` for task-specific setup (cloning the right branch, writing the task's rules).
+All other isol8 isolation guarantees apply regardless of network mode: read-only root filesystem, non-root `sandbox` user, seccomp syscall filtering, `/sandbox` tmpfs, and automatic secret masking in output.
 
 ## Related pages
 
@@ -592,7 +448,7 @@ const engine = new DockerIsol8({
     Full reference for the agent runtime: flags, networking, file injection, and streaming.
   </Card>
   <Card title="Setup scripts" icon="scroll" href="/setup-scripts">
-    Full reference for setupScript: image-level vs request-level, execution order, and common patterns.
+    Image-level vs request-level setup, execution order, streaming output, and error handling.
   </Card>
   <Card title="AI agent code execution" icon="robot" href="/guides/ai-agents">
     Foundational patterns for LLM tool-call loops with isol8.

--- a/apps/docs/setup-scripts.mdx
+++ b/apps/docs/setup-scripts.mdx
@@ -148,7 +148,7 @@ Both image-level and request-level scripts run with the same constraints:
 - **Working directory**: `/sandbox`
 - **Shell**: `bash`
 - **Timeout**: subject to the same `timeoutMs` as the full execution request
-- **Exit code**: a non-zero exit from the setup script aborts the execution and throws `Setup script failed (exit code N): <stderr>`
+- **Exit code**: a non-zero exit from the setup script aborts the execution before the main code runs (see [Error handling](#error-handling) below)
 - **Secrets**: values from the engine's `secrets` option are available as environment variables and are automatically masked in stdout/stderr
 
 ## Execution order
@@ -160,6 +160,8 @@ When both levels are set, the order is deterministic:
 2. Request-level setup script (from ExecutionRequest.setupScript, per-call)
 3. Main code / agent prompt
 ```
+
+If any stage exits non-zero, the remaining stages do not run. In streaming mode, `StreamEvent` objects with `phase: "setup"` are emitted during stages 1–2, and `phase: "code"` during stage 3.
 
 ## Common patterns
 
@@ -262,7 +264,9 @@ await engine.stop();
 
 ## Error handling
 
-If the setup script exits non-zero, isol8 throws before running your code:
+### Non-streaming (`execute`)
+
+If the setup script exits non-zero, `execute()` throws before running your code:
 
 ```
 Error: Setup script failed (exit code 1): fatal: repository 'https://github.com/my-org/private-repo.git/' not found
@@ -281,6 +285,36 @@ await engine.execute({
 });
 ```
 
+### Streaming (`executeStream`)
+
+When using `executeStream`, setup-script output is yielded as `StreamEvent` objects with `phase: "setup"` before any `phase: "code"` events appear. If the script exits non-zero, the stream emits a `{ type: "error", phase: "setup" }` event followed by the `exit` event, and the main code never runs — no further events are yielded.
+
+```typescript
+for await (const event of engine.executeStream({
+  runtime: "bash",
+  setupScript: "git clone https://$GITHUB_TOKEN@github.com/my-org/repo.git /sandbox/repo",
+  code: "ls /sandbox/repo",
+})) {
+  if (event.phase === "setup") {
+    // stdout/stderr/error from the setup script
+    if (event.type === "error") {
+      console.error("Setup failed:", event.data);
+    } else if (event.type === "exit" && event.data !== "0") {
+      console.error("Setup exited with code", event.data);
+      // No more events will follow — main code did not run
+    }
+  } else {
+    // phase === "code" — main code output
+    if (event.type === "stdout") process.stdout.write(event.data);
+    if (event.type === "stderr") process.stderr.write(event.data);
+  }
+}
+```
+
+<Note>
+  The `phase` field is optional on `StreamEvent` for backward compatibility, but is always set by isol8 — setup events always carry `"setup"` and main code events always carry `"code"`. Checking `event.phase === "setup"` is safe.
+</Note>
+
 ## Related pages
 
 <CardGroup cols={2}>
@@ -294,6 +328,9 @@ await engine.execute({
     Run the pi coding agent inside isol8 — setup scripts prepare the workspace before the agent starts.
   </Card>
   <Card title="One-shot coding agents" icon="wand-magic-sparkles" href="/guides/one-shot-coding-agents">
-    End-to-end blueprint: clone repo, implement, lint, test, create PR — setup scripts handle context hydration.
+    Architecture and pipeline: clone repo, implement, verify, fix, and open a PR — setup scripts handle context hydration.
+  </Card>
+  <Card title="Execution guide" icon="terminal" href="/execution">
+    Streaming output, execution modes, resource limits, and file I/O.
   </Card>
 </CardGroup>

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -324,11 +324,32 @@ export async function createServer(options: ServerOptions) {
       poolSize: config.poolSize,
       remoteCode: config.remoteCode,
       ...requestOptions,
-      mode: "ephemeral",
+      mode: body.sessionId ? "persistent" : "ephemeral",
+      audit: config.audit,
     };
 
-    const engine = new DockerIsol8(engineOptions, config.maxConcurrent);
-    await engine.start();
+    let engine: DockerIsol8;
+    let isSessionEngine = false;
+
+    if (body.sessionId) {
+      const session = sessions.get(body.sessionId);
+      if (session) {
+        logger.debug(`[Server] Reusing existing session for stream: ${body.sessionId}`);
+        engine = session.engine;
+        session.lastAccessedAt = Date.now();
+        session.isActive = true;
+      } else {
+        logger.debug(`[Server] Creating new session for stream: ${body.sessionId}`);
+        engine = new DockerIsol8(engineOptions, config.maxConcurrent);
+        await engine.start();
+        sessions.set(body.sessionId, { engine, lastAccessedAt: Date.now(), isActive: true });
+      }
+      isSessionEngine = true;
+    } else {
+      logger.debug("[Server] Creating ephemeral engine for stream");
+      engine = new DockerIsol8(engineOptions, config.maxConcurrent);
+      await engine.start();
+    }
 
     const encoder = new TextEncoder();
     const stream = new ReadableStream({
@@ -351,8 +372,16 @@ export async function createServer(options: ServerOptions) {
           const errorEvent = `data: ${JSON.stringify({ type: "error", data: message })}\n\n`;
           controller.enqueue(encoder.encode(errorEvent));
         } finally {
-          logger.debug("[Server] Cleaning up stream engine");
-          await engine.stop();
+          if (isSessionEngine && body.sessionId) {
+            const session = sessions.get(body.sessionId);
+            if (session) {
+              session.isActive = false;
+              session.lastAccessedAt = Date.now();
+            }
+          } else {
+            logger.debug("[Server] Cleaning up ephemeral stream engine");
+            await engine.stop();
+          }
           controller.close();
         }
       },
@@ -431,13 +460,33 @@ export async function createServer(options: ServerOptions) {
             poolSize: config.poolSize,
             remoteCode: config.remoteCode,
             ...requestOptions,
-            mode: "ephemeral",
+            mode: msg.sessionId ? "persistent" : "ephemeral",
+            audit: config.audit,
           };
 
-          const engine = new DockerIsol8(engineOptions, config.maxConcurrent);
+          let engine: DockerIsol8;
+          let isSessionEngine = false;
+
+          if (msg.sessionId) {
+            const session = sessions.get(msg.sessionId);
+            if (session) {
+              logger.debug(`[Server] WebSocket reusing existing session: ${msg.sessionId}`);
+              engine = session.engine;
+              session.lastAccessedAt = Date.now();
+              session.isActive = true;
+            } else {
+              logger.debug(`[Server] WebSocket creating new session: ${msg.sessionId}`);
+              engine = new DockerIsol8(engineOptions, config.maxConcurrent);
+              await engine.start();
+              sessions.set(msg.sessionId, { engine, lastAccessedAt: Date.now(), isActive: true });
+            }
+            isSessionEngine = true;
+          } else {
+            engine = new DockerIsol8(engineOptions, config.maxConcurrent);
+            await engine.start();
+          }
 
           try {
-            await engine.start();
             logger.debug("[Server] WebSocket: acquiring semaphore");
             await globalSemaphore.acquire();
             try {
@@ -453,8 +502,16 @@ export async function createServer(options: ServerOptions) {
             logger.debug(`[Server] WebSocket stream error: ${message}`);
             ws.send(JSON.stringify({ type: "error", data: message }));
           } finally {
-            logger.debug("[Server] WebSocket: cleaning up engine");
-            await engine.stop();
+            if (isSessionEngine && msg.sessionId) {
+              const session = sessions.get(msg.sessionId);
+              if (session) {
+                session.isActive = false;
+                session.lastAccessedAt = Date.now();
+              }
+            } else {
+              logger.debug("[Server] WebSocket: cleaning up ephemeral engine");
+              await engine.stop();
+            }
             ws.close(1000, "Execution complete");
           }
         },

--- a/packages/core/docker/Dockerfile
+++ b/packages/core/docker/Dockerfile
@@ -1,6 +1,6 @@
 # ── Base ──────────────────────────────────────────────────────────────
 FROM alpine:3.21 AS base
-RUN apk add --no-cache tini curl ca-certificates iptables bash git \
+RUN apk add --no-cache tini curl ca-certificates iptables bash git github-cli \
     && addgroup -S sandbox && adduser -S sandbox -G sandbox -h /sandbox
 COPY proxy.sh /usr/local/bin/proxy.sh
 COPY proxy-handler.sh /usr/local/bin/proxy-handler.sh

--- a/packages/core/src/engine/docker.ts
+++ b/packages/core/src/engine/docker.ts
@@ -91,17 +91,23 @@ export class DockerIsol8 implements Isol8Engine {
   private pool: ContainerPool | null = null;
   private readonly imageCache = new Map<string, string>();
 
-  private async resolveExecutionRequest(
-    req: ExecutionRequest
-  ): Promise<ExecutionRequest & { code: string }> {
+  private async resolveExecutionRequest(req: ExecutionRequest): Promise<ExecutionRequest> {
     const inlineCode = req.code?.trim();
     const codeUrl = req.codeUrl?.trim();
+    const cmd = req.cmd?.trim();
 
-    if (inlineCode && codeUrl) {
-      throw new Error("ExecutionRequest.code and ExecutionRequest.codeUrl are mutually exclusive.");
+    const sourceCount = [inlineCode, codeUrl, cmd].filter(Boolean).length;
+    if (sourceCount > 1) {
+      throw new Error(
+        "ExecutionRequest.code, ExecutionRequest.codeUrl, and ExecutionRequest.cmd are mutually exclusive — provide exactly one."
+      );
     }
-    if (!(inlineCode || codeUrl)) {
-      throw new Error("ExecutionRequest must include either code or codeUrl.");
+    if (sourceCount === 0) {
+      throw new Error("ExecutionRequest must include exactly one of: code, codeUrl, or cmd.");
+    }
+
+    if (cmd) {
+      return { ...req, cmd: req.cmd! };
     }
 
     if (inlineCode) {
@@ -277,7 +283,7 @@ export class DockerIsol8 implements Isol8Engine {
    * Record an audit entry for the execution.
    */
   private async recordAudit(
-    req: ExecutionRequest & { code: string },
+    req: ExecutionRequest,
     result: ExecutionResult,
     startTime: number,
     container?: Docker.Container
@@ -285,7 +291,7 @@ export class DockerIsol8 implements Isol8Engine {
     try {
       // Calculate code hash using Web Crypto API
       const enc = new TextEncoder();
-      const data = enc.encode(req.code);
+      const data = enc.encode(req.code ?? req.cmd ?? "");
       const digest = await crypto.subtle.digest("SHA-256", data);
       const codeHash = Array.from(new Uint8Array(digest))
         .map((b) => b.toString(16).padStart(2, "0"))
@@ -506,9 +512,7 @@ export class DockerIsol8 implements Isol8Engine {
    * Streaming execution in persistent mode — reuses the long-lived container so that
    * filesystem state is preserved across calls, mirroring {@link executePersistent}.
    */
-  private async *executeStreamPersistent(
-    request: ExecutionRequest & { code: string }
-  ): AsyncIterable<StreamEvent> {
+  private async *executeStreamPersistent(request: ExecutionRequest): AsyncIterable<StreamEvent> {
     const adapter = this.getAdapter(request.runtime);
     const timeoutMs = request.timeoutMs ?? this.defaultTimeoutMs;
     const execWorkdir = request.workdir ? resolveWorkdir(request.workdir) : SANDBOX_WORKDIR;
@@ -527,10 +531,18 @@ export class DockerIsol8 implements Isol8Engine {
       );
     }
 
-    const ext = request.fileExtension ?? adapter.getFileExtension();
-    const filePath = `${SANDBOX_WORKDIR}/exec_${Date.now()}${ext}`;
+    let rawCmd: string[];
+    if (request.cmd) {
+      // cmd mode: run bash command directly, no file write needed
+      rawCmd = ["bash", "-c", request.cmd];
+    } else {
+      const ext = request.fileExtension ?? adapter.getFileExtension();
+      const filePath = `${SANDBOX_WORKDIR}/exec_${Date.now()}${ext}`;
 
-    await this.volumeManager.putFile(this.container!, filePath, request.code);
+      await this.volumeManager.putFile(this.container!, filePath, request.code!);
+
+      rawCmd = this.buildAdapterCommand(adapter, request, filePath);
+    }
 
     // Inject input files
     if (request.files) {
@@ -539,7 +551,6 @@ export class DockerIsol8 implements Isol8Engine {
       }
     }
 
-    // Install packages if requested
     if (remainingPackages.length > 0) {
       await this.executionManager.installPackages(
         this.container!,
@@ -551,25 +562,42 @@ export class DockerIsol8 implements Isol8Engine {
 
     // Run image-level setup script if the resolved image carries one
     if (imageSetupScript) {
-      await this.executionManager.runSetupScript(
+      let setupExitCode = 0;
+      for await (const event of this.executionManager.runSetupScript(
         this.container!,
         imageSetupScript,
         timeoutMs,
         this.volumeManager
-      );
+      )) {
+        yield event;
+        if (event.type === "exit") {
+          setupExitCode = Number(event.data);
+        }
+      }
+      if (setupExitCode !== 0) {
+        return;
+      }
     }
 
     // Run request-level setup script if provided
     if (request.setupScript) {
-      await this.executionManager.runSetupScript(
+      let setupExitCode = 0;
+      for await (const event of this.executionManager.runSetupScript(
         this.container!,
         request.setupScript,
         timeoutMs,
         this.volumeManager
-      );
+      )) {
+        yield event;
+        if (event.type === "exit") {
+          setupExitCode = Number(event.data);
+        }
+      }
+      if (setupExitCode !== 0) {
+        return;
+      }
     }
 
-    const rawCmd = this.buildAdapterCommand(adapter, request, filePath);
     const timeoutSec = Math.ceil(timeoutMs / 1000);
     let cmd: string[];
     if (request.stdin) {
@@ -607,9 +635,7 @@ export class DockerIsol8 implements Isol8Engine {
    * Streaming execution in ephemeral mode — acquires a pre-warmed container from the pool,
    * streams output, then returns the container to the pool for reuse.
    */
-  private async *executeStreamEphemeral(
-    request: ExecutionRequest & { code: string }
-  ): AsyncIterable<StreamEvent> {
+  private async *executeStreamEphemeral(request: ExecutionRequest): AsyncIterable<StreamEvent> {
     const adapter = this.getAdapter(request.runtime);
     const timeoutMs = request.timeoutMs ?? this.defaultTimeoutMs;
     const resolved = await this.resolveImage(adapter, request.installPackages);
@@ -624,11 +650,6 @@ export class DockerIsol8 implements Isol8Engine {
       await this.networkManager.startProxy(container);
       await this.networkManager.setupIptables(container);
 
-      // Write code
-      const ext = request.fileExtension ?? adapter.getFileExtension();
-      const filePath = `${SANDBOX_WORKDIR}/main${ext}`;
-      await this.volumeManager.writeFileViaExec(container, filePath, request.code);
-
       // Install packages if requested
       if (resolved.remainingPackages.length > 0) {
         await this.executionManager.installPackages(
@@ -641,22 +662,40 @@ export class DockerIsol8 implements Isol8Engine {
 
       // Run image-level setup script if the resolved image carries one
       if (resolved.imageSetupScript) {
-        await this.executionManager.runSetupScript(
+        let setupExitCode = 0;
+        for await (const event of this.executionManager.runSetupScript(
           container,
           resolved.imageSetupScript,
           timeoutMs,
           this.volumeManager
-        );
+        )) {
+          yield event;
+          if (event.type === "exit") {
+            setupExitCode = Number(event.data);
+          }
+        }
+        if (setupExitCode !== 0) {
+          return;
+        }
       }
 
       // Run request-level setup script if provided
       if (request.setupScript) {
-        await this.executionManager.runSetupScript(
+        let setupExitCode = 0;
+        for await (const event of this.executionManager.runSetupScript(
           container,
           request.setupScript,
           timeoutMs,
           this.volumeManager
-        );
+        )) {
+          yield event;
+          if (event.type === "exit") {
+            setupExitCode = Number(event.data);
+          }
+        }
+        if (setupExitCode !== 0) {
+          return;
+        }
       }
 
       // Inject input files
@@ -667,7 +706,18 @@ export class DockerIsol8 implements Isol8Engine {
       }
 
       // Build command
-      const rawCmd = this.buildAdapterCommand(adapter, request, filePath);
+      let rawCmd: string[];
+      if (request.cmd) {
+        // cmd mode: run bash command directly, no file write needed
+        rawCmd = ["bash", "-c", request.cmd];
+      } else {
+        // Write code to file and build adapter command
+        const ext = request.fileExtension ?? adapter.getFileExtension();
+        const filePath = `${SANDBOX_WORKDIR}/main${ext}`;
+        await this.volumeManager.writeFileViaExec(container, filePath, request.code!);
+        rawCmd = this.buildAdapterCommand(adapter, request, filePath);
+      }
+
       const timeoutSec = Math.ceil(timeoutMs / 1000);
       let cmd: string[];
       if (request.stdin) {
@@ -861,7 +911,7 @@ export class DockerIsol8 implements Isol8Engine {
   }
 
   private async executeEphemeral(
-    req: ExecutionRequest & { code: string },
+    req: ExecutionRequest,
     startTime: number
   ): Promise<ExecutionResult> {
     const adapter = this.getAdapter(req.runtime);
@@ -894,25 +944,30 @@ export class DockerIsol8 implements Isol8Engine {
       // Fast path: for simple executions, avoid file write and execute inline.
       // Falls back to file-based path for runtimes that require file input (e.g. Deno)
       // or when request options require filesystem artifacts.
-      const canUseInline =
-        !(req.stdin || req.files || req.outputPaths) &&
-        (!req.installPackages || req.installPackages.length === 0);
-
       let rawCmd: string[];
-      if (canUseInline) {
-        try {
-          rawCmd = this.buildAdapterCommand(adapter, req);
-        } catch {
+      if (req.cmd) {
+        // cmd mode: run bash command directly, no file write needed
+        rawCmd = ["bash", "-c", req.cmd];
+      } else {
+        const canUseInline =
+          !(req.stdin || req.files || req.outputPaths) &&
+          (!req.installPackages || req.installPackages.length === 0);
+
+        if (canUseInline) {
+          try {
+            rawCmd = this.buildAdapterCommand(adapter, req);
+          } catch {
+            const ext = req.fileExtension ?? adapter.getFileExtension();
+            const filePath = `${SANDBOX_WORKDIR}/main${ext}`;
+            await this.volumeManager.writeFileViaExec(container, filePath, req.code!);
+            rawCmd = this.buildAdapterCommand(adapter, req, filePath);
+          }
+        } else {
           const ext = req.fileExtension ?? adapter.getFileExtension();
           const filePath = `${SANDBOX_WORKDIR}/main${ext}`;
-          await this.volumeManager.writeFileViaExec(container, filePath, req.code);
+          await this.volumeManager.writeFileViaExec(container, filePath, req.code!);
           rawCmd = this.buildAdapterCommand(adapter, req, filePath);
         }
-      } else {
-        const ext = req.fileExtension ?? adapter.getFileExtension();
-        const filePath = `${SANDBOX_WORKDIR}/main${ext}`;
-        await this.volumeManager.writeFileViaExec(container, filePath, req.code);
-        rawCmd = this.buildAdapterCommand(adapter, req, filePath);
       }
 
       // Install packages if requested
@@ -927,22 +982,46 @@ export class DockerIsol8 implements Isol8Engine {
 
       // Run image-level setup script if the resolved image carries one
       if (resolved.imageSetupScript) {
-        await this.executionManager.runSetupScript(
+        let stderr = "";
+        let exitCode = 0;
+        for await (const event of this.executionManager.runSetupScript(
           container,
           resolved.imageSetupScript,
           timeoutMs,
           this.volumeManager
-        );
+        )) {
+          if (event.type === "stderr") {
+            stderr += event.data;
+          }
+          if (event.type === "exit") {
+            exitCode = Number(event.data);
+          }
+        }
+        if (exitCode !== 0) {
+          throw new Error(`Setup script failed (exit code ${exitCode}): ${stderr}`);
+        }
       }
 
       // Run request-level setup script if provided
       if (req.setupScript) {
-        await this.executionManager.runSetupScript(
+        let stderr = "";
+        let exitCode = 0;
+        for await (const event of this.executionManager.runSetupScript(
           container,
           req.setupScript,
           timeoutMs,
           this.volumeManager
-        );
+        )) {
+          if (event.type === "stderr") {
+            stderr += event.data;
+          }
+          if (event.type === "exit") {
+            exitCode = Number(event.data);
+          }
+        }
+        if (exitCode !== 0) {
+          throw new Error(`Setup script failed (exit code ${exitCode}): ${stderr}`);
+        }
       }
 
       // Execute the actual command, wrapped with timeout to ensure kill on expiry
@@ -1056,7 +1135,7 @@ export class DockerIsol8 implements Isol8Engine {
   }
 
   private async executePersistent(
-    req: ExecutionRequest & { code: string },
+    req: ExecutionRequest,
     startTime: number
   ): Promise<ExecutionResult> {
     const adapter = this.getAdapter(req.runtime);
@@ -1077,11 +1156,19 @@ export class DockerIsol8 implements Isol8Engine {
       );
     }
 
-    const ext = req.fileExtension ?? adapter.getFileExtension();
-    const filePath = `${SANDBOX_WORKDIR}/exec_${Date.now()}${ext}`;
+    let rawCmd: string[];
+    if (req.cmd) {
+      // cmd mode: run bash command directly, no file write needed
+      rawCmd = ["bash", "-c", req.cmd];
+    } else {
+      const ext = req.fileExtension ?? adapter.getFileExtension();
+      const filePath = `${SANDBOX_WORKDIR}/exec_${Date.now()}${ext}`;
 
-    // Write code to the container
-    await this.volumeManager.putFile(this.container!, filePath, req.code);
+      // Write code to the container
+      await this.volumeManager.putFile(this.container!, filePath, req.code!);
+
+      rawCmd = this.buildAdapterCommand(adapter, req, filePath);
+    }
 
     // Inject input files
     if (req.files) {
@@ -1090,7 +1177,6 @@ export class DockerIsol8 implements Isol8Engine {
       }
     }
 
-    const rawCmd = this.buildAdapterCommand(adapter, req, filePath);
     const timeoutSec = Math.ceil(timeoutMs / 1000);
 
     // Install packages if requested
@@ -1105,22 +1191,46 @@ export class DockerIsol8 implements Isol8Engine {
 
     // Run image-level setup script if the resolved image carries one
     if (imageSetupScript) {
-      await this.executionManager.runSetupScript(
+      let stderr = "";
+      let exitCode = 0;
+      for await (const event of this.executionManager.runSetupScript(
         this.container!,
         imageSetupScript,
         timeoutMs,
         this.volumeManager
-      );
+      )) {
+        if (event.type === "stderr") {
+          stderr += event.data;
+        }
+        if (event.type === "exit") {
+          exitCode = Number(event.data);
+        }
+      }
+      if (exitCode !== 0) {
+        throw new Error(`Setup script failed (exit code ${exitCode}): ${stderr}`);
+      }
     }
 
     // Run request-level setup script if provided
     if (req.setupScript) {
-      await this.executionManager.runSetupScript(
+      let stderr = "";
+      let exitCode = 0;
+      for await (const event of this.executionManager.runSetupScript(
         this.container!,
         req.setupScript,
         timeoutMs,
         this.volumeManager
-      );
+      )) {
+        if (event.type === "stderr") {
+          stderr += event.data;
+        }
+        if (event.type === "exit") {
+          exitCode = Number(event.data);
+        }
+      }
+      if (exitCode !== 0) {
+        throw new Error(`Setup script failed (exit code ${exitCode}): ${stderr}`);
+      }
     }
 
     // Handle stdin
@@ -1271,29 +1381,32 @@ export class DockerIsol8 implements Isol8Engine {
 
   /**
    * Validate agent runtime requirements. The agent runtime requires
-   * filtered network mode with at least one whitelist entry so that
-   * the AI coding agent can reach its LLM provider API.
+   * either filtered network mode (with at least one whitelist entry) or
+   * host network mode so that the AI coding agent can reach its LLM
+   * provider API.
    */
   private validateAgentRuntime(req: ExecutionRequest): void {
     if (req.runtime !== "agent") {
       return;
     }
 
-    if (this.network !== "filtered") {
+    if (this.network === "none") {
       throw new Error(
-        'Agent runtime requires network mode "filtered". ' +
-          "The AI coding agent needs network access to reach its LLM provider API. " +
-          'Use --net filtered --allow "api.anthropic.com" (or your provider\'s domain).'
+        "Agent runtime requires network access. " +
+          "The AI coding agent needs to reach its LLM provider API. " +
+          'Use --net host, or --net filtered --allow "api.anthropic.com" (or your provider\'s domain).'
       );
     }
 
-    const whitelist = this.networkFilter?.whitelist ?? [];
-    if (whitelist.length === 0) {
-      throw new Error(
-        "Agent runtime requires at least one network whitelist entry. " +
-          "The AI coding agent needs to reach its LLM provider API. " +
-          'Use --allow "api.anthropic.com" (or your provider\'s domain).'
-      );
+    if (this.network === "filtered") {
+      const whitelist = this.networkFilter?.whitelist ?? [];
+      if (whitelist.length === 0) {
+        throw new Error(
+          "Agent runtime requires at least one network whitelist entry. " +
+            "The AI coding agent needs to reach its LLM provider API. " +
+            'Use --allow "api.anthropic.com" (or your provider\'s domain).'
+        );
+      }
     }
   }
 
@@ -1303,16 +1416,17 @@ export class DockerIsol8 implements Isol8Engine {
    */
   private buildAdapterCommand(
     adapter: RuntimeAdapter,
-    req: ExecutionRequest & { code: string },
+    req: ExecutionRequest,
     filePath?: string
   ): string[] {
+    const code = req.code ?? "";
     if (adapter.getCommandWithOptions) {
-      return adapter.getCommandWithOptions(req.code, {
+      return adapter.getCommandWithOptions(code, {
         filePath,
         agentFlags: req.agentFlags,
       });
     }
-    return adapter.getCommand(req.code, filePath);
+    return adapter.getCommand(code, filePath);
   }
 
   private buildHostConfig(): Docker.HostConfig {

--- a/packages/core/src/engine/docker.ts
+++ b/packages/core/src/engine/docker.ts
@@ -481,128 +481,234 @@ export class DockerIsol8 implements Isol8Engine {
   /**
    * Execute code and stream output chunks as they arrive.
    * Yields {@link StreamEvent} objects for stdout, stderr, exit, and error events.
+   *
+   * Respects the engine mode:
+   * - **Persistent** — reuses `this.container` across calls, preserving filesystem state.
+   * - **Ephemeral** — acquires a pre-warmed container from the pool and returns it after use.
    */
   async *executeStream(req: ExecutionRequest): AsyncIterable<StreamEvent> {
     await this.semaphore.acquire();
     try {
       this.validateAgentRuntime(req);
       const request = await this.resolveExecutionRequest(req);
-      const adapter = this.getAdapter(request.runtime);
-      const timeoutMs = request.timeoutMs ?? this.defaultTimeoutMs;
-      const resolved = await this.resolveImage(adapter, request.installPackages);
-      const image = resolved.image;
-      const execWorkdir = request.workdir ? resolveWorkdir(request.workdir) : SANDBOX_WORKDIR;
 
-      // Create container (always ephemeral-style for streaming)
-      const container: Docker.Container = await this.docker.createContainer({
-        Image: image,
-        Cmd: ["sleep", "infinity"],
-        WorkingDir: SANDBOX_WORKDIR,
+      if (this.mode === "persistent") {
+        yield* this.executeStreamPersistent(request);
+      } else {
+        yield* this.executeStreamEphemeral(request);
+      }
+    } finally {
+      this.semaphore.release();
+    }
+  }
+
+  /**
+   * Streaming execution in persistent mode — reuses the long-lived container so that
+   * filesystem state is preserved across calls, mirroring {@link executePersistent}.
+   */
+  private async *executeStreamPersistent(
+    request: ExecutionRequest & { code: string }
+  ): AsyncIterable<StreamEvent> {
+    const adapter = this.getAdapter(request.runtime);
+    const timeoutMs = request.timeoutMs ?? this.defaultTimeoutMs;
+    const execWorkdir = request.workdir ? resolveWorkdir(request.workdir) : SANDBOX_WORKDIR;
+
+    let remainingPackages = request.installPackages ?? [];
+    let imageSetupScript: string | undefined;
+
+    // Lazily create the persistent container (same logic as executePersistent)
+    if (!this.container) {
+      const started = await this.startPersistentContainer(adapter, request.installPackages);
+      remainingPackages = started.remainingPackages;
+      imageSetupScript = started.imageSetupScript;
+    } else if (this.persistentRuntime?.name !== adapter.name) {
+      throw new Error(
+        `Cannot switch runtime from "${this.persistentRuntime?.name}" to "${adapter.name}". Each persistent container supports a single runtime. Create a new Isol8 instance for a different runtime.`
+      );
+    }
+
+    const ext = request.fileExtension ?? adapter.getFileExtension();
+    const filePath = `${SANDBOX_WORKDIR}/exec_${Date.now()}${ext}`;
+
+    await this.volumeManager.putFile(this.container!, filePath, request.code);
+
+    // Inject input files
+    if (request.files) {
+      for (const [fPath, fContent] of Object.entries(request.files)) {
+        await this.volumeManager.putFile(this.container!, fPath, fContent);
+      }
+    }
+
+    // Install packages if requested
+    if (remainingPackages.length > 0) {
+      await this.executionManager.installPackages(
+        this.container!,
+        request.runtime,
+        remainingPackages,
+        timeoutMs
+      );
+    }
+
+    // Run image-level setup script if the resolved image carries one
+    if (imageSetupScript) {
+      await this.executionManager.runSetupScript(
+        this.container!,
+        imageSetupScript,
+        timeoutMs,
+        this.volumeManager
+      );
+    }
+
+    // Run request-level setup script if provided
+    if (request.setupScript) {
+      await this.executionManager.runSetupScript(
+        this.container!,
+        request.setupScript,
+        timeoutMs,
+        this.volumeManager
+      );
+    }
+
+    const rawCmd = this.buildAdapterCommand(adapter, request, filePath);
+    const timeoutSec = Math.ceil(timeoutMs / 1000);
+    let cmd: string[];
+    if (request.stdin) {
+      const stdinPath = `${SANDBOX_WORKDIR}/_stdin_${Date.now()}`;
+      await this.volumeManager.writeFileViaExec(this.container!, stdinPath, request.stdin);
+      const cmdStr = rawCmd.map((a) => `'${a.replace(/'/g, "'\\''")}'`).join(" ");
+      cmd = this.executionManager.wrapWithTimeout(
+        ["sh", "-c", `cat ${stdinPath} | ${cmdStr}`],
+        timeoutSec
+      );
+    } else {
+      cmd = this.executionManager.wrapWithTimeout(rawCmd, timeoutSec);
+    }
+
+    const exec = await this.container!.exec({
+      Cmd: cmd,
+      Env: this.executionManager.buildEnv(
+        request.env,
+        this.networkManager.proxyPort,
+        this.network,
+        this.networkFilter
+      ),
+      AttachStdout: true,
+      AttachStderr: true,
+      WorkingDir: execWorkdir,
+      User: "sandbox",
+    });
+
+    const execStream = await exec.start({ Tty: false });
+
+    yield* this.executionManager.streamExecOutput(execStream, exec, this.container!, timeoutMs);
+  }
+
+  /**
+   * Streaming execution in ephemeral mode — acquires a pre-warmed container from the pool,
+   * streams output, then returns the container to the pool for reuse.
+   */
+  private async *executeStreamEphemeral(
+    request: ExecutionRequest & { code: string }
+  ): AsyncIterable<StreamEvent> {
+    const adapter = this.getAdapter(request.runtime);
+    const timeoutMs = request.timeoutMs ?? this.defaultTimeoutMs;
+    const resolved = await this.resolveImage(adapter, request.installPackages);
+    const image = resolved.image;
+    const execWorkdir = request.workdir ? resolveWorkdir(request.workdir) : SANDBOX_WORKDIR;
+
+    // Acquire a pre-warmed container from the pool
+    const pool = this.ensurePool();
+    const container = await pool.acquire(image);
+
+    try {
+      await this.networkManager.startProxy(container);
+      await this.networkManager.setupIptables(container);
+
+      // Write code
+      const ext = request.fileExtension ?? adapter.getFileExtension();
+      const filePath = `${SANDBOX_WORKDIR}/main${ext}`;
+      await this.volumeManager.writeFileViaExec(container, filePath, request.code);
+
+      // Install packages if requested
+      if (resolved.remainingPackages.length > 0) {
+        await this.executionManager.installPackages(
+          container,
+          request.runtime,
+          resolved.remainingPackages,
+          timeoutMs
+        );
+      }
+
+      // Run image-level setup script if the resolved image carries one
+      if (resolved.imageSetupScript) {
+        await this.executionManager.runSetupScript(
+          container,
+          resolved.imageSetupScript,
+          timeoutMs,
+          this.volumeManager
+        );
+      }
+
+      // Run request-level setup script if provided
+      if (request.setupScript) {
+        await this.executionManager.runSetupScript(
+          container,
+          request.setupScript,
+          timeoutMs,
+          this.volumeManager
+        );
+      }
+
+      // Inject input files
+      if (request.files) {
+        for (const [fPath, fContent] of Object.entries(request.files)) {
+          await this.volumeManager.writeFileViaExec(container, fPath, fContent);
+        }
+      }
+
+      // Build command
+      const rawCmd = this.buildAdapterCommand(adapter, request, filePath);
+      const timeoutSec = Math.ceil(timeoutMs / 1000);
+      let cmd: string[];
+      if (request.stdin) {
+        const stdinPath = `${SANDBOX_WORKDIR}/_stdin`;
+        await this.volumeManager.writeFileViaExec(container, stdinPath, request.stdin);
+        const cmdStr = rawCmd.map((a) => `'${a.replace(/'/g, "'\\''")}'`).join(" ");
+        cmd = this.executionManager.wrapWithTimeout(
+          ["sh", "-c", `cat ${stdinPath} | ${cmdStr}`],
+          timeoutSec
+        );
+      } else {
+        cmd = this.executionManager.wrapWithTimeout(rawCmd, timeoutSec);
+      }
+
+      const exec = await container.exec({
+        Cmd: cmd,
         Env: this.executionManager.buildEnv(
-          undefined,
+          request.env,
           this.networkManager.proxyPort,
           this.network,
           this.networkFilter
         ),
-        NetworkDisabled: this.network === "none",
-        HostConfig: this.buildHostConfig(),
-        StopTimeout: 2,
+        AttachStdout: true,
+        AttachStderr: true,
+        WorkingDir: execWorkdir,
+        User: "sandbox",
       });
 
-      try {
-        await container.start();
+      const execStream = await exec.start({ Tty: false });
 
-        await this.networkManager.startProxy(container);
-        await this.networkManager.setupIptables(container);
-
-        // Write code
-        const ext = request.fileExtension ?? adapter.getFileExtension();
-        const filePath = `${SANDBOX_WORKDIR}/main${ext}`;
-        await this.volumeManager.writeFileViaExec(container, filePath, request.code);
-
-        // Install packages if requested
-        if (resolved.remainingPackages.length > 0) {
-          await this.executionManager.installPackages(
-            container,
-            request.runtime,
-            resolved.remainingPackages,
-            timeoutMs
-          );
-        }
-
-        // Run image-level setup script if the resolved image carries one
-        if (resolved.imageSetupScript) {
-          await this.executionManager.runSetupScript(
-            container,
-            resolved.imageSetupScript,
-            timeoutMs,
-            this.volumeManager
-          );
-        }
-
-        // Run request-level setup script if provided
-        if (request.setupScript) {
-          await this.executionManager.runSetupScript(
-            container,
-            request.setupScript,
-            timeoutMs,
-            this.volumeManager
-          );
-        }
-
-        // Inject input files
-        if (request.files) {
-          for (const [fPath, fContent] of Object.entries(request.files)) {
-            await this.volumeManager.writeFileViaExec(container, fPath, fContent);
-          }
-        }
-
-        // Build command
-        const rawCmd = this.buildAdapterCommand(adapter, request, filePath);
-        const timeoutSec = Math.ceil(timeoutMs / 1000);
-        let cmd: string[];
-        if (request.stdin) {
-          const stdinPath = `${SANDBOX_WORKDIR}/_stdin`;
-          await this.volumeManager.writeFileViaExec(container, stdinPath, request.stdin);
-          const cmdStr = rawCmd.map((a) => `'${a.replace(/'/g, "'\\''")}'`).join(" ");
-          cmd = this.executionManager.wrapWithTimeout(
-            ["sh", "-c", `cat ${stdinPath} | ${cmdStr}`],
-            timeoutSec
-          );
-        } else {
-          cmd = this.executionManager.wrapWithTimeout(rawCmd, timeoutSec);
-        }
-
-        const exec = await container.exec({
-          Cmd: cmd,
-          Env: this.executionManager.buildEnv(
-            request.env,
-            this.networkManager.proxyPort,
-            this.network,
-            this.networkFilter
-          ),
-          AttachStdout: true,
-          AttachStderr: true,
-          WorkingDir: execWorkdir,
-          User: "sandbox",
-        });
-
-        const execStream = await exec.start({ Tty: false });
-
-        yield* this.executionManager.streamExecOutput(execStream, exec, container, timeoutMs);
-      } finally {
-        if (this.persist) {
-          logger.debug(`[Persist] Leaving container running for inspection: ${container.id}`);
-        } else {
-          try {
-            await container.remove({ force: true });
-          } catch {
-            // Best effort cleanup
-          }
-        }
-      }
+      yield* this.executionManager.streamExecOutput(execStream, exec, container, timeoutMs);
     } finally {
-      this.semaphore.release();
+      if (this.persist) {
+        logger.debug(`[Persist] Leaving container running for inspection: ${container.id}`);
+      } else {
+        // Return container to pool for reuse - fire-and-forget for performance
+        pool.release(container, image).catch((err) => {
+          logger.debug(`[Pool] release failed: ${err}`);
+          container.remove({ force: true }).catch(() => {});
+        });
+      }
     }
   }
 

--- a/packages/core/src/engine/managers/execution-manager.ts
+++ b/packages/core/src/engine/managers/execution-manager.ts
@@ -133,12 +133,12 @@ export class ExecutionManager {
     });
   }
 
-  async runSetupScript(
+  async *runSetupScript(
     container: Docker.Container,
     script: string,
     timeoutMs: number,
     volumeManager: VolumeManager
-  ): Promise<void> {
+  ): AsyncGenerator<StreamEvent> {
     const scriptPath = "/sandbox/.isol8-setup.sh";
     await volumeManager.writeFileViaExec(container, scriptPath, script);
 
@@ -173,39 +173,76 @@ export class ExecutionManager {
 
     const stream = await exec.start({ Detach: false, Tty: false });
 
-    return new Promise<void>((resolve, reject) => {
-      let stderr = "";
-      const stdoutStream = new PassThrough();
-      const stderrStream = new PassThrough();
+    const queue: StreamEvent[] = [];
+    let notify: (() => void) | null = null;
+    let done = false;
 
-      container.modem.demuxStream(stream, stdoutStream, stderrStream);
+    const push = (event: StreamEvent) => {
+      queue.push(event);
+      if (notify) {
+        notify();
+        notify = null;
+      }
+    };
 
-      stderrStream.on("data", (chunk) => {
-        const text = chunk.toString();
-        stderr += text;
-        logger.debug(`[setup:stderr] ${text.trimEnd()}`);
-      });
+    const timer = setTimeout(() => {
+      push({ type: "error", data: "SETUP SCRIPT TIMED OUT", phase: "setup" });
+      push({ type: "exit", data: "137", phase: "setup" });
+      done = true;
+    }, timeoutMs);
 
-      stdoutStream.on("data", (chunk) => {
-        const text = chunk.toString();
-        logger.debug(`[setup:stdout] ${text.trimEnd()}`);
-      });
+    const stdoutStream = new PassThrough();
+    const stderrStream = new PassThrough();
 
-      stream.on("end", async () => {
-        try {
-          const info = await exec.inspect();
-          if (info.ExitCode !== 0) {
-            reject(new Error(`Setup script failed (exit code ${info.ExitCode}): ${stderr}`));
-          } else {
-            resolve();
-          }
-        } catch (err) {
-          reject(err);
-        }
-      });
+    container.modem.demuxStream(stream, stdoutStream, stderrStream);
 
-      stream.on("error", reject);
+    stdoutStream.on("data", (chunk: Buffer) => {
+      const text = chunk.toString("utf-8");
+      logger.debug(`[setup:stdout] ${text.trimEnd()}`);
+      push({ type: "stdout", data: text, phase: "setup" });
     });
+
+    stderrStream.on("data", (chunk: Buffer) => {
+      const text = chunk.toString("utf-8");
+      logger.debug(`[setup:stderr] ${text.trimEnd()}`);
+      push({ type: "stderr", data: text, phase: "setup" });
+    });
+
+    stream.on("end", async () => {
+      clearTimeout(timer);
+      try {
+        const info = await exec.inspect();
+        const exitCode = info.ExitCode ?? 0;
+        if (exitCode !== 0) {
+          push({
+            type: "error",
+            data: `Setup script failed (exit code ${exitCode})`,
+            phase: "setup",
+          });
+        }
+        push({ type: "exit", data: exitCode.toString(), phase: "setup" });
+      } catch {
+        push({ type: "exit", data: "1", phase: "setup" });
+      }
+      done = true;
+    });
+
+    stream.on("error", (err: Error) => {
+      clearTimeout(timer);
+      push({ type: "error", data: err.message, phase: "setup" });
+      push({ type: "exit", data: "1", phase: "setup" });
+      done = true;
+    });
+
+    while (!done || queue.length > 0) {
+      if (queue.length > 0) {
+        yield queue.shift()!;
+      } else {
+        await new Promise<void>((r) => {
+          notify = r;
+        });
+      }
+    }
   }
 
   async *streamExecOutput(
@@ -227,8 +264,8 @@ export class ExecutionManager {
     };
 
     const timer = setTimeout(() => {
-      push({ type: "error", data: "EXECUTION TIMED OUT" });
-      push({ type: "exit", data: "137" });
+      push({ type: "error", data: "EXECUTION TIMED OUT", phase: "code" });
+      push({ type: "exit", data: "137", phase: "code" });
       done = true;
     }, timeoutMs);
 
@@ -242,7 +279,7 @@ export class ExecutionManager {
       if (Object.keys(this.secrets).length > 0) {
         text = maskSecrets(text, this.secrets);
       }
-      push({ type: "stdout", data: text });
+      push({ type: "stdout", data: text, phase: "code" });
     });
 
     stderrStream.on("data", (chunk: Buffer) => {
@@ -250,24 +287,24 @@ export class ExecutionManager {
       if (Object.keys(this.secrets).length > 0) {
         text = maskSecrets(text, this.secrets);
       }
-      push({ type: "stderr", data: text });
+      push({ type: "stderr", data: text, phase: "code" });
     });
 
     stream.on("end", async () => {
       clearTimeout(timer);
       try {
         const info = await exec.inspect();
-        push({ type: "exit", data: (info.ExitCode ?? 0).toString() });
+        push({ type: "exit", data: (info.ExitCode ?? 0).toString(), phase: "code" });
       } catch {
-        push({ type: "exit", data: "1" });
+        push({ type: "exit", data: "1", phase: "code" });
       }
       done = true;
     });
 
     stream.on("error", (err: Error) => {
       clearTimeout(timer);
-      push({ type: "error", data: err.message });
-      push({ type: "exit", data: "1" });
+      push({ type: "error", data: err.message, phase: "code" });
+      push({ type: "exit", data: "1", phase: "code" });
       done = true;
     });
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -35,15 +35,24 @@ export type NetworkMode = "none" | "host" | "filtered";
 export interface ExecutionRequest {
   /**
    * Source code to execute.
-   * Mutually exclusive with {@link codeUrl}.
+   * Mutually exclusive with {@link codeUrl} and {@link cmd}.
    */
   code?: string;
 
   /**
    * Remote URL to fetch source code from before execution.
-   * Mutually exclusive with {@link code}.
+   * Mutually exclusive with {@link code} and {@link cmd}.
    */
   codeUrl?: string;
+
+  /**
+   * Bash command(s) to run inside the sandbox container.
+   * Always executed via `bash -c` regardless of the `runtime` field.
+   * Mutually exclusive with {@link code} and {@link codeUrl}.
+   * @example "npm install && npm test"
+   * @example "git clone https://github.com/user/repo && cd repo && make"
+   */
+  cmd?: string;
 
   /** Expected SHA-256 hash (hex) of the fetched source code. */
   codeHash?: string;
@@ -201,6 +210,13 @@ export interface StreamEvent {
   type: "stdout" | "stderr" | "exit" | "error";
   /** Text content for stdout/stderr, exit code string for exit, error message for error. */
   data: string;
+  /**
+   * Execution phase that produced this event.
+   *
+   * - `"setup"` — emitted during `setupScript` execution (image-level or request-level).
+   * - `"code"` — emitted during main code / command execution.
+   */
+  phase?: "setup" | "code";
 }
 
 // ─── WebSocket Messages ───

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -213,7 +213,7 @@ export interface StreamEvent {
  * - `"signal"` — Send a control signal to the running process (reserved for future use).
  */
 export type WsClientMessage =
-  | { type: "execute"; request: ExecutionRequest; options?: Isol8Options }
+  | { type: "execute"; request: ExecutionRequest; options?: Isol8Options; sessionId?: string }
   | { type: "stdin"; data: string }
   | { type: "signal"; signal: "SIGINT" | "SIGTERM" };
 

--- a/packages/core/tests/unit/agent-validation.test.ts
+++ b/packages/core/tests/unit/agent-validation.test.ts
@@ -5,9 +5,11 @@ import { DockerIsol8 } from "../../src/engine/docker";
 /**
  * Tests for the agent runtime validation logic in DockerIsol8.
  *
- * The engine enforces that agent runtime executions use network: "filtered"
- * with at least one whitelist entry. These tests verify that constraint
- * via the public execute() API.
+ * The engine enforces that agent runtime executions use either:
+ * - network: "filtered" with at least one whitelist entry, or
+ * - network: "host" (full network access)
+ *
+ * network: "none" is always rejected for agent runtime.
  */
 describe("Agent runtime validation", () => {
   const createMockDocker = () => {
@@ -54,7 +56,7 @@ describe("Agent runtime validation", () => {
     return { docker, container, createContainer, removeMock };
   };
 
-  // ── Validation: network mode ──
+  // ── Validation: network: "none" is always rejected ──
 
   test("rejects agent runtime with network: 'none'", async () => {
     const { docker } = createMockDocker();
@@ -69,26 +71,10 @@ describe("Agent runtime validation", () => {
         code: "Write hello world",
         runtime: "agent",
       })
-    ).rejects.toThrow('Agent runtime requires network mode "filtered"');
+    ).rejects.toThrow("Agent runtime requires network access");
   });
 
-  test("rejects agent runtime with network: 'host'", async () => {
-    const { docker } = createMockDocker();
-    const engine = new DockerIsol8({
-      docker,
-      mode: "ephemeral",
-      network: "host",
-    });
-
-    await expect(
-      engine.execute({
-        code: "Write hello world",
-        runtime: "agent",
-      })
-    ).rejects.toThrow('Agent runtime requires network mode "filtered"');
-  });
-
-  // ── Validation: whitelist required ──
+  // ── Validation: filtered requires whitelist ──
 
   test("rejects agent runtime with empty whitelist", async () => {
     const { docker } = createMockDocker();
@@ -131,7 +117,6 @@ describe("Agent runtime validation", () => {
 
   test("accepts agent runtime with filtered network and whitelist", () => {
     const { docker } = createMockDocker();
-    // Construction should succeed — validation happens in execute()
     const engine = new DockerIsol8({
       docker,
       mode: "ephemeral",
@@ -140,6 +125,16 @@ describe("Agent runtime validation", () => {
         whitelist: ["^api\\.anthropic\\.com$"],
         blacklist: [],
       },
+    });
+    expect(engine).toBeDefined();
+  });
+
+  test("accepts agent runtime with network: 'host'", () => {
+    const { docker } = createMockDocker();
+    const engine = new DockerIsol8({
+      docker,
+      mode: "ephemeral",
+      network: "host",
     });
     expect(engine).toBeDefined();
   });

--- a/packages/core/tests/unit/cmd-validation.test.ts
+++ b/packages/core/tests/unit/cmd-validation.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test";
+import { DockerIsol8 } from "../../src/engine/docker";
+
+class TestDockerIsol8 extends DockerIsol8 {
+  testResolveExecutionRequest(req: any) {
+    return (this as any).resolveExecutionRequest(req);
+  }
+}
+
+const engine = new TestDockerIsol8({ mode: "ephemeral" });
+
+describe("resolveExecutionRequest — cmd mutual exclusion", () => {
+  test("accepts cmd alone", async () => {
+    const result = await engine.testResolveExecutionRequest({
+      cmd: "echo hello",
+      runtime: "bash",
+    });
+    expect(result.cmd).toBe("echo hello");
+    expect(result.code).toBeUndefined();
+  });
+
+  test("accepts code alone", async () => {
+    const result = await engine.testResolveExecutionRequest({
+      code: "print('hi')",
+      runtime: "python",
+    });
+    expect(result.code).toBe("print('hi')");
+    expect(result.cmd).toBeUndefined();
+  });
+
+  test("rejects cmd + code together", async () => {
+    expect(
+      engine.testResolveExecutionRequest({
+        cmd: "echo hello",
+        code: "print('hi')",
+        runtime: "python",
+      })
+    ).rejects.toThrow("mutually exclusive");
+  });
+
+  test("rejects cmd + codeUrl together", async () => {
+    expect(
+      engine.testResolveExecutionRequest({
+        cmd: "echo hello",
+        codeUrl: "https://example.com/script.py",
+        runtime: "python",
+      })
+    ).rejects.toThrow("mutually exclusive");
+  });
+
+  test("rejects code + codeUrl together (existing behaviour)", async () => {
+    expect(
+      engine.testResolveExecutionRequest({
+        code: "print('hi')",
+        codeUrl: "https://example.com/script.py",
+        runtime: "python",
+      })
+    ).rejects.toThrow("mutually exclusive");
+  });
+
+  test("rejects empty request (no code, codeUrl, or cmd)", async () => {
+    expect(
+      engine.testResolveExecutionRequest({
+        runtime: "python",
+      })
+    ).rejects.toThrow("exactly one of");
+  });
+
+  test("treats whitespace-only cmd as absent", async () => {
+    expect(
+      engine.testResolveExecutionRequest({
+        cmd: "   ",
+        runtime: "bash",
+      })
+    ).rejects.toThrow("exactly one of");
+  });
+
+  test("cmd value is preserved on the returned request", async () => {
+    const result = await engine.testResolveExecutionRequest({
+      cmd: "npm test",
+      runtime: "node",
+      env: { NODE_ENV: "test" },
+    });
+    expect(result.cmd).toBe("npm test");
+    expect(result.runtime).toBe("node");
+    expect(result.env).toEqual({ NODE_ENV: "test" });
+  });
+});

--- a/packages/core/tests/unit/websocket-types.test.ts
+++ b/packages/core/tests/unit/websocket-types.test.ts
@@ -169,6 +169,60 @@ describe("WsServerMessage", () => {
   });
 });
 
+describe("StreamEvent phase field", () => {
+  test("phase is optional — events without phase are valid", () => {
+    const event: StreamEvent = { type: "stdout", data: "hello\n" };
+    expect(event.phase).toBeUndefined();
+  });
+
+  test("phase: 'setup' marks setup script output", () => {
+    const events: StreamEvent[] = [
+      { type: "stdout", data: "cloning repo...\n", phase: "setup" },
+      { type: "stderr", data: "warning: detached HEAD\n", phase: "setup" },
+      { type: "exit", data: "0", phase: "setup" },
+    ];
+
+    for (const e of events) {
+      expect(e.phase).toBe("setup");
+    }
+  });
+
+  test("phase: 'code' marks main code output", () => {
+    const events: StreamEvent[] = [
+      { type: "stdout", data: "hello world\n", phase: "code" },
+      { type: "stderr", data: "some warning\n", phase: "code" },
+      { type: "exit", data: "0", phase: "code" },
+    ];
+
+    for (const e of events) {
+      expect(e.phase).toBe("code");
+    }
+  });
+
+  test("error event during setup carries phase: 'setup'", () => {
+    const event: StreamEvent = {
+      type: "error",
+      data: "Setup script failed (exit code 1)",
+      phase: "setup",
+    };
+    expect(event.type).toBe("error");
+    expect(event.phase).toBe("setup");
+  });
+
+  test("JSON round-trip preserves phase field", () => {
+    const original: StreamEvent = { type: "stdout", data: "output\n", phase: "setup" };
+    const parsed = JSON.parse(JSON.stringify(original)) as StreamEvent;
+    expect(parsed).toEqual(original);
+    expect(parsed.phase).toBe("setup");
+  });
+
+  test("JSON round-trip — phase absent when not set", () => {
+    const original: StreamEvent = { type: "stdout", data: "output\n" };
+    const parsed = JSON.parse(JSON.stringify(original)) as StreamEvent;
+    expect(parsed.phase).toBeUndefined();
+  });
+});
+
 describe("WebSocket message parsing (simulated server logic)", () => {
   test("valid JSON parses as WsClientMessage", () => {
     const raw = JSON.stringify({


### PR DESCRIPTION
## Summary

- Add `ExecutionRequest.cmd` field for running arbitrary bash commands in the sandbox via `bash -c`, mutually exclusive with `code`/`codeUrl`
- Add `StreamEvent.phase` (`"setup"` | `"code"`) to distinguish setup script output from main execution output
- Allow `network: "host"` for agent runtime (previously only `"filtered"` was accepted)
- Setup script streaming with early exit on non-zero exit code
- CLI gains `--cmd <command>` flag (defaults runtime to `bash`)

## Docs

- **Rewrite `one-shot-coding-agents.mdx`**: Remove all Maxions references, add mermaid architecture/pipeline diagrams, present clients as generic (GitHub bots, Slack bots, web UIs, CLI scripts), reference Stripe Minions as motivating concept
- **Update `agent-in-a-box.mdx`**: Networking section (host now allowed for agent), streaming section (phase filtering)
- **Update `setup-scripts.mdx`**: Execution order with phase info, error handling for streaming vs non-streaming
- **Update `execution.mdx`**: StreamEvent reference table with phase field, phase-based code examples

## Changeset

`@isol8/core` minor, `@isol8/cli` minor — see `.changeset/add-cmd-field.md`

## Test coverage

- `packages/core/tests/unit/cmd-validation.test.ts` — cmd field validation
- `packages/core/tests/unit/agent-validation.test.ts` — updated agent runtime validation (host network)
- `packages/core/tests/unit/websocket-types.test.ts` — StreamEvent.phase type tests
- `apps/cli/tests/integration/cmd.test.ts` — CLI --cmd flag integration tests