### PR TITLE
fix: custom image tagging, selective runtime builds, and config fixes

### DIFF
--- a/.changeset/fix-build-stream-error-log.md
+++ b/.changeset/fix-build-stream-error-log.md
@@ -1,0 +1,5 @@
+---
+"@isol8/core": patch
+---
+
+Docker build stream output is now accumulated and included in error messages when `buildBaseImages` or `buildCustomImage` fails. Previously only the final error event was surfaced; the full build log (including pip tracebacks and layer output) is now appended to the thrown error.

--- a/.changeset/fix-config-dependencies-shorthand.md
+++ b/.changeset/fix-config-dependencies-shorthand.md
@@ -1,0 +1,5 @@
+---
+"@isol8/core": minor
+---
+
+Add `dependencies` shorthand field to `isol8.config.json`. Specifying `{ "dependencies": { "python": ["numpy", "pandas"] } }` is now equivalent to a `prebuiltImages` entry, making per-runtime package declarations more concise. Entries from `dependencies` are appended after any explicit `prebuiltImages`.

--- a/.changeset/fix-python-alpine-to-slim.md
+++ b/.changeset/fix-python-alpine-to-slim.md
@@ -1,0 +1,5 @@
+---
+"@isol8/core": patch
+---
+
+Switch the Python Docker image from Alpine Linux to `python:3.12-slim` (Debian). This fixes installation failures for data-science packages such as `numpy`, `scipy`, `matplotlib`, and `statsmodels` that require pre-built manylinux wheels not available on Alpine's musl libc.

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -110,7 +110,7 @@ program
     }
 
     // Auto-build prebuilt images from config
-    const config = loadConfig();
+    const config = loadConfig(process.cwd());
     if (config.prebuiltImages.length > 0) {
       console.log("");
       spinner.start("Checking prebuilt images from config...");
@@ -925,7 +925,7 @@ program
   .description("Show the resolved isol8 configuration")
   .option("--json", "Output as raw JSON")
   .action((opts) => {
-    const config = loadConfig();
+    const config = loadConfig(process.cwd());
 
     // Determine which config file was loaded
     const searchPaths = [
@@ -1382,7 +1382,7 @@ sessionCmd
 
 // biome-ignore lint/suspicious/noExplicitAny: commander opts are untyped
 async function resolveRunInput(file: string | undefined, opts: any) {
-  const config = loadConfig();
+  const config = loadConfig(process.cwd());
   logger.debug("[Run] Config loaded");
   const hasExplicitNetFlag = process.argv.some((arg) => arg === "--net");
 

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -54,13 +54,42 @@ program
 
 // ─── setup ────────────────────────────────────────────────────────────
 
+const VALID_RUNTIMES = ["python", "node", "bun", "deno", "bash", "agent"];
+
 program
   .command("setup")
-  .description("Check Docker and build isol8 base images")
+  .description("Check Docker and build isol8 base images. Use --only to build a subset.")
   .option("--force", "Force rebuild even if images are up to date")
+  .option(
+    "--only <runtimes...>",
+    `Only build images for these runtimes (e.g. --only python, --only python node, --only python,node). Valid: ${VALID_RUNTIMES.join(", ")}`
+  )
   .action(async (opts) => {
     const docker = new Docker();
     logger.debug("[Setup] Connecting to Docker daemon");
+
+    // Parse and validate --only
+    const onlyRuntimes: string[] | undefined = opts.only
+      ? [
+          ...new Set(
+            (opts.only as string[])
+              .flatMap((r: string) => r.split(","))
+              .map((r: string) => r.trim())
+              .filter(Boolean)
+          ),
+        ]
+      : undefined;
+
+    if (onlyRuntimes) {
+      const invalid = onlyRuntimes.filter((r) => !VALID_RUNTIMES.includes(r));
+      if (invalid.length > 0) {
+        console.error(
+          `[ERR] Unknown runtime(s): ${invalid.join(", ")}. Valid: ${VALID_RUNTIMES.join(", ")}`
+        );
+        process.exit(1);
+      }
+      logger.debug(`[Setup] Filtering to runtimes: ${onlyRuntimes.join(", ")}`);
+    }
 
     // Check Docker connection
     const spinner = ora("Checking Docker...").start();
@@ -99,22 +128,23 @@ program
           }
         }
       },
-      opts.force ?? false
+      opts.force ?? false,
+      onlyRuntimes
     );
     if (spinner.isSpinning) {
       spinner.stop();
     }
 
-    if (spinner.isSpinning) {
-      spinner.stop();
-    }
-
-    // Auto-build prebuilt images from config
+    // Auto-build prebuilt images from config (filtered by --only if specified)
     const config = loadConfig(process.cwd());
-    if (config.prebuiltImages.length > 0) {
+    const imagesToBuild = onlyRuntimes
+      ? config.prebuiltImages.filter((img) => onlyRuntimes.includes(img.runtime))
+      : config.prebuiltImages;
+
+    if (imagesToBuild.length > 0) {
       console.log("");
       spinner.start("Checking prebuilt images from config...");
-      for (const img of config.prebuiltImages) {
+      for (const img of imagesToBuild) {
         const exists = await imageExists(docker, img.tag);
         if (exists && !(opts.force ?? false)) {
           spinner.stopAndPersist({ symbol: "[OK]", text: `${img.tag} (already exists)` });

--- a/packages/core/docker/Dockerfile
+++ b/packages/core/docker/Dockerfile
@@ -9,8 +9,20 @@ WORKDIR /sandbox
 ENTRYPOINT ["/sbin/tini", "--"]
 
 # ── Python ────────────────────────────────────────────────────────────
-FROM base AS python
-RUN apk add --no-cache python3 py3-pip
+# Uses python:3.12-slim (Debian) instead of Alpine so that pre-built
+# manylinux/musllinux wheels are available for data-science packages
+# (numpy, scipy, matplotlib, statsmodels, etc.).
+FROM python:3.12-slim AS python
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        tini curl ca-certificates iptables bash git \
+    && rm -rf /var/lib/apt/lists/* \
+    && groupadd -r sandbox && useradd -r -g sandbox -d /sandbox -s /bin/bash sandbox \
+    && mkdir -p /sandbox && chown sandbox:sandbox /sandbox
+COPY proxy.sh /usr/local/bin/proxy.sh
+COPY proxy-handler.sh /usr/local/bin/proxy-handler.sh
+RUN chmod +x /usr/local/bin/proxy.sh /usr/local/bin/proxy-handler.sh
+WORKDIR /sandbox
+ENTRYPOINT ["/usr/bin/tini", "--"]
 CMD ["python3"]
 
 # ── Node ──────────────────────────────────────────────────────────────

--- a/packages/core/docker/Dockerfile
+++ b/packages/core/docker/Dockerfile
@@ -16,7 +16,7 @@ FROM python:3.12-slim AS python
 RUN apt-get update && apt-get install -y --no-install-recommends \
         tini curl ca-certificates iptables bash git \
     && rm -rf /var/lib/apt/lists/* \
-    && groupadd -r sandbox && useradd -r -g sandbox -d /sandbox -s /bin/bash sandbox \
+    && groupadd -r --gid 101 sandbox && useradd -r --uid 100 -g sandbox -d /sandbox -s /bin/bash sandbox \
     && mkdir -p /sandbox && chown sandbox:sandbox /sandbox
 COPY proxy.sh /usr/local/bin/proxy.sh
 COPY proxy-handler.sh /usr/local/bin/proxy-handler.sh

--- a/packages/core/schema/isol8.config.schema.json
+++ b/packages/core/schema/isol8.config.schema.json
@@ -147,6 +147,49 @@
           },
           "type": "object"
         },
+        "dependencies": {
+          "additionalProperties": false,
+          "description": "Shorthand for declaring per-runtime package dependencies. Each key is a runtime name and the value is a list of packages to pre-install into a custom image for that runtime.\n\nEquivalent to `prebuiltImages` but more concise.  When both are specified, entries from `dependencies` are appended to `prebuiltImages`.",
+          "properties": {
+            "agent": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "bash": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "bun": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "deno": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "node": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "python": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
         "maxConcurrent": {
           "default": 10,
           "description": "Maximum number of containers that can run concurrently.",

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -9,7 +9,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
-import type { Isol8Config } from "./types";
+import type { Isol8Config, Isol8UserConfig, PrebuiltImageConfig, Runtime } from "./types";
 
 /**
  * Built-in default configuration. Used as the base for all config merges.
@@ -110,7 +110,7 @@ export function loadConfig(cwd?: string): Isol8Config {
   for (const configPath of searchPaths) {
     if (existsSync(configPath)) {
       const raw = readFileSync(configPath, "utf-8");
-      const parsed = JSON.parse(raw) as Partial<Isol8Config>;
+      const parsed = JSON.parse(raw) as Partial<Isol8UserConfig>;
       return mergeConfig(DEFAULT_CONFIG, parsed);
     }
   }
@@ -119,11 +119,38 @@ export function loadConfig(cwd?: string): Isol8Config {
 }
 
 /**
+ * Expands the `dependencies` shorthand into `prebuiltImages` entries.
+ *
+ * `{ dependencies: { python: ["numpy"] } }` expands to:
+ * `[{ tag: "isol8:python-custom", runtime: "python", installPackages: ["numpy"] }]`
+ */
+function expandDependencies(
+  deps: Partial<Record<Runtime, string[]>> | undefined
+): PrebuiltImageConfig[] {
+  if (!deps) {
+    return [];
+  }
+  return (Object.entries(deps) as [Runtime, string[]][]).map(([runtime, packages]) => ({
+    tag: `isol8:${runtime}-custom`,
+    runtime,
+    installPackages: packages,
+  }));
+}
+
+/**
  * Deep-merges a partial config with defaults. Each top-level section is merged
  * independently so that specifying e.g. `{ defaults: { timeoutMs: 5000 } }`
  * preserves all other default values.
+ *
+ * The `dependencies` shorthand field (from `Isol8UserConfig`) is expanded into
+ * `prebuiltImages` entries and appended after any explicit `prebuiltImages`.
  */
-function mergeConfig(defaults: Isol8Config, overrides: Partial<Isol8Config>): Isol8Config {
+function mergeConfig(defaults: Isol8Config, overrides: Partial<Isol8UserConfig>): Isol8Config {
+  const explicitPrebuilt = overrides.prebuiltImages ?? defaults.prebuiltImages;
+  const fromDeps = expandDependencies(overrides.dependencies);
+  const prebuiltImages =
+    fromDeps.length > 0 ? [...explicitPrebuilt, ...fromDeps] : explicitPrebuilt;
+
   return {
     maxConcurrent: overrides.maxConcurrent ?? defaults.maxConcurrent,
     defaults: {
@@ -161,7 +188,7 @@ function mergeConfig(defaults: Isol8Config, overrides: Partial<Isol8Config>): Is
       ...defaults.auth,
       ...overrides.auth,
     },
-    prebuiltImages: overrides.prebuiltImages ?? defaults.prebuiltImages,
+    prebuiltImages,
     debug: overrides.debug ?? defaults.debug,
   };
 }

--- a/packages/core/src/engine/image-builder.ts
+++ b/packages/core/src/engine/image-builder.ts
@@ -9,6 +9,7 @@
 import { createHash } from "node:crypto";
 import { existsSync, readFileSync, statSync } from "node:fs";
 import { dirname, join } from "node:path";
+import { Readable } from "node:stream";
 import type Docker from "dockerode";
 import { RuntimeRegistry } from "../runtime";
 import { logger } from "../utils/logger";
@@ -234,13 +235,25 @@ export async function buildBaseImages(
 
       // Wait for build to complete
       await new Promise<void>((resolve, reject) => {
-        docker.modem.followProgress(stream, (err) => {
-          if (err) {
-            reject(err);
-          } else {
-            resolve();
+        const buildLog: string[] = [];
+        docker.modem.followProgress(
+          stream,
+          (err) => {
+            if (err) {
+              const log = buildLog.join("").trim();
+              const detail = log ? `\n--- build log ---\n${log}\n-----------------` : "";
+              reject(new Error(`${err instanceof Error ? err.message : String(err)}${detail}`));
+            } else {
+              resolve();
+            }
+          },
+          // biome-ignore lint/suspicious/noExplicitAny: stream chunk type is ambiguous
+          (event: any) => {
+            if (event.stream) {
+              buildLog.push(event.stream);
+            }
           }
-        });
+        );
       });
 
       // Clean up the old image if it existed and was replaced
@@ -350,23 +363,27 @@ export async function buildCustomImage(
     imageLabels[LABELS.setupScript] = setupScript;
   }
 
-  // biome-ignore lint/suspicious/noExplicitAny: Dockerode is missing raw Buffer support typings
-  const stream = await docker.buildImage(tarBuffer as any, {
+  const stream = await docker.buildImage(Readable.from(tarBuffer), {
     t: tag,
     dockerfile: "Dockerfile",
     labels: imageLabels,
   });
 
   await new Promise<void>((resolve, reject) => {
+    const buildLog: string[] = [];
     docker.modem.followProgress(
       // biome-ignore lint/suspicious/noExplicitAny: Dockerode is missing raw Buffer support typings
       stream as any,
       // biome-ignore lint/suspicious/noExplicitAny: Dockerode callback types are not exact for modem
       (err: any, res: any) => {
         if (err) {
-          reject(err);
+          const log = buildLog.join("").trim();
+          const detail = log ? `\n--- build log ---\n${log}\n-----------------` : "";
+          reject(new Error(`${err instanceof Error ? err.message : String(err)}${detail}`));
         } else if (res && res.length > 0 && res.at(-1).error) {
-          reject(new Error(res.at(-1).error));
+          const log = buildLog.join("").trim();
+          const detail = log ? `\n--- build log ---\n${log}\n-----------------` : "";
+          reject(new Error(`${res.at(-1).error}${detail}`));
         } else {
           resolve();
         }
@@ -374,6 +391,7 @@ export async function buildCustomImage(
       // biome-ignore lint/suspicious/noExplicitAny: stream chunk type is ambiguous
       (event: any) => {
         if (event.stream) {
+          buildLog.push(event.stream);
           onProgress?.({ runtime: String(runtime), status: "building", message: event.stream });
         } else if (event.error) {
           onProgress?.({ runtime: String(runtime), status: "error", message: event.error });

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -722,4 +722,27 @@ export interface Isol8UserConfig {
    * unless `--force` is passed.
    */
   prebuiltImages?: PrebuiltImageConfig[];
+
+  /**
+   * Shorthand for declaring per-runtime package dependencies.
+   * Each key is a runtime name and the value is a list of packages to
+   * pre-install into a custom image for that runtime.
+   *
+   * Equivalent to `prebuiltImages` but more concise.  When both are
+   * specified, entries from `dependencies` are appended to `prebuiltImages`.
+   *
+   * @example
+   * ```json
+   * { "dependencies": { "python": ["numpy", "pandas", "scipy"] } }
+   * ```
+   * This is equivalent to:
+   * ```json
+   * {
+   *   "prebuiltImages": [
+   *     { "tag": "isol8:python-custom", "runtime": "python", "installPackages": ["numpy", "pandas", "scipy"] }
+   *   ]
+   * }
+   * ```
+   */
+  dependencies?: Partial<Record<Runtime, string[]>>;
 }

--- a/packages/core/tests/unit/config.test.ts
+++ b/packages/core/tests/unit/config.test.ts
@@ -126,3 +126,88 @@ describe("loadConfig", () => {
     rmSync(tmpDir, { recursive: true });
   });
 });
+
+describe("loadConfig — dependencies shorthand", () => {
+  const tmpDir = join(tmpdir(), `isol8-deps-test-${Date.now()}`);
+
+  test("dependencies shorthand expands to prebuiltImages", () => {
+    mkdirSync(tmpDir, { recursive: true });
+    writeFileSync(
+      join(tmpDir, "isol8.config.json"),
+      JSON.stringify({
+        dependencies: {
+          python: ["numpy", "pandas", "scipy"],
+        },
+      })
+    );
+
+    const config = loadConfig(tmpDir);
+    expect(config.prebuiltImages).toHaveLength(1);
+    expect(config.prebuiltImages[0]).toEqual({
+      tag: "isol8:python-custom",
+      runtime: "python",
+      installPackages: ["numpy", "pandas", "scipy"],
+    });
+
+    rmSync(tmpDir, { recursive: true });
+  });
+
+  test("dependencies shorthand supports multiple runtimes", () => {
+    mkdirSync(tmpDir, { recursive: true });
+    writeFileSync(
+      join(tmpDir, "isol8.config.json"),
+      JSON.stringify({
+        dependencies: {
+          python: ["numpy"],
+          node: ["lodash"],
+        },
+      })
+    );
+
+    const config = loadConfig(tmpDir);
+    expect(config.prebuiltImages).toHaveLength(2);
+    const runtimes = config.prebuiltImages.map((p) => p.runtime).sort();
+    expect(runtimes).toEqual(["node", "python"]);
+
+    rmSync(tmpDir, { recursive: true });
+  });
+
+  test("dependencies entries are appended after explicit prebuiltImages", () => {
+    mkdirSync(tmpDir, { recursive: true });
+    writeFileSync(
+      join(tmpDir, "isol8.config.json"),
+      JSON.stringify({
+        prebuiltImages: [{ tag: "my-custom:v1", runtime: "python", installPackages: ["requests"] }],
+        dependencies: {
+          node: ["express"],
+        },
+      })
+    );
+
+    const config = loadConfig(tmpDir);
+    expect(config.prebuiltImages).toHaveLength(2);
+    expect(config.prebuiltImages[0].tag).toBe("my-custom:v1");
+    expect(config.prebuiltImages[1].tag).toBe("isol8:node-custom");
+    expect(config.prebuiltImages[1].installPackages).toEqual(["express"]);
+
+    rmSync(tmpDir, { recursive: true });
+  });
+
+  test("config without dependencies produces empty prebuiltImages by default", () => {
+    const config = loadConfig("/nonexistent/path");
+    expect(config.prebuiltImages).toEqual([]);
+  });
+
+  test("dependencies shorthand generates correct tag format", () => {
+    mkdirSync(tmpDir, { recursive: true });
+    writeFileSync(
+      join(tmpDir, "isol8.config.json"),
+      JSON.stringify({ dependencies: { bun: ["hono"] } })
+    );
+
+    const config = loadConfig(tmpDir);
+    expect(config.prebuiltImages[0].tag).toBe("isol8:bun-custom");
+
+    rmSync(tmpDir, { recursive: true });
+  });
+});

--- a/packages/core/tests/unit/image-builder.test.ts
+++ b/packages/core/tests/unit/image-builder.test.ts
@@ -1,31 +1,69 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { createHash } from "node:crypto";
-import { buildCustomImage, imageExists, normalizePackages } from "../../src/engine/image-builder";
+import { Readable } from "node:stream";
+import {
+  buildBaseImages,
+  buildCustomImage,
+  imageExists,
+  normalizePackages,
+} from "../../src/engine/image-builder";
+import { extractFromTar } from "../../src/engine/utils";
 
-// Mock Dockerode
-const mockBuildImage = mock(() => {
-  return Promise.resolve({
-    // Mock stream
-    on: (event: string, cb: any) => {},
-    pipe: (dest: any) => dest, // Helper for piping if needed
-  });
-});
+// ─── Shared mock factory ─────────────────────────────────────────────────────
+
+/** Creates a fresh mock docker client that records buildImage calls and succeeds by default. */
+function makeMockDocker(
+  overrides: { inspectResult?: object; followProgressResult?: { err?: any; res?: any[] } } = {}
+) {
+  const buildImage = mock(() => Promise.resolve({ on: () => {}, pipe: (d: any) => d }));
+
+  const followProgress = mock(
+    (_stream: any, cb: (err?: any, res?: any[]) => void, _onEvent?: (e: any) => void) => {
+      const { err = null, res = [] } = overrides.followProgressResult ?? {};
+      cb(err, res);
+    }
+  );
+
+  const docker = {
+    buildImage,
+    modem: { followProgress },
+    getImage: (_id?: string) => ({
+      inspect: async () => overrides.inspectResult ?? {},
+      remove: async () => {},
+    }),
+  } as any;
+
+  return { docker, buildImage, followProgress };
+}
+
+/** Reads all bytes from a Readable stream into a Buffer. */
+async function readStream(stream: Readable): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks);
+}
+
+// ─── Legacy shared mocks (kept for existing tests) ───────────────────────────
+
+const mockBuildImage = mock(() =>
+  Promise.resolve({ on: (_event: string, _cb: any) => {}, pipe: (dest: any) => dest })
+);
 
 const mockFollowProgress = mock((stream: any, cb: (err?: any) => void) => {
-  cb(null); // Success
+  cb(null);
 });
 
 const mockDocker = {
   buildImage: mockBuildImage,
-  modem: {
-    followProgress: mockFollowProgress,
-  },
-  getImage: () => ({
-    inspect: async () => ({}),
-  }),
+  modem: { followProgress: mockFollowProgress },
+  getImage: () => ({ inspect: async () => ({}) }),
 } as any;
 
-describe("image-builder", () => {
+// ─── buildCustomImage: stream shape ──────────────────────────────────────────
+
+describe("buildCustomImage — stream passed to docker.buildImage", () => {
   beforeEach(() => {
     mockBuildImage.mockClear();
     mockFollowProgress.mockClear();
@@ -33,24 +71,338 @@ describe("image-builder", () => {
 
   test("builds custom image with valid package names", async () => {
     await buildCustomImage(mockDocker, "python", ["numpy", "pandas"], "my-custom-python-tag");
-
     expect(mockBuildImage).toHaveBeenCalled();
-    // Verify arguments to buildImage (harder with tar stream, but we can verify it was called)
   });
 
-  test("throws error for malicious python package name", async () => {
-    // This should fail once validation is added
-    // For now (before fix), checking that it DOES NOT throw would show the bug,
-    // but we want to assert the DESIRED behavior (throwing error).
-    expect(buildCustomImage(mockDocker, "python", ["numpy; rm -rf /"], "tag")).rejects.toThrow(
-      /Invalid package name/
+  test("passes a Readable stream (not a raw Buffer) — regression for <none>:<none> tag bug", async () => {
+    await buildCustomImage(mockDocker, "python", ["numpy"], "isol8:python-custom-abc123");
+
+    const calls = mockBuildImage.mock.calls as unknown as [unknown, unknown][];
+    const firstArg = calls[0][0];
+
+    // A raw Buffer passed here causes Docker to build the image but silently omit the tag,
+    // resulting in <none>:<none> dangling images. It must be a Readable stream.
+    expect(firstArg).toBeInstanceOf(Readable);
+    expect(Buffer.isBuffer(firstArg)).toBe(false);
+  });
+
+  test.each([
+    "python",
+    "node",
+    "bun",
+    "bash",
+  ] as const)("passes a Readable stream for runtime: %s", async (runtime) => {
+    const { docker, buildImage } = makeMockDocker();
+    await buildCustomImage(docker, runtime, ["pkg"], `isol8:${runtime}-custom`);
+
+    const calls = buildImage.mock.calls as unknown as [unknown, unknown][];
+    expect(calls[0][0]).toBeInstanceOf(Readable);
+    expect(Buffer.isBuffer(calls[0][0])).toBe(false);
+  });
+
+  test("the Readable stream can actually be consumed (is not empty)", async () => {
+    const { docker, buildImage } = makeMockDocker();
+    await buildCustomImage(docker, "python", ["numpy"], "isol8:python-test");
+
+    const calls = buildImage.mock.calls as unknown as [Readable, unknown][];
+    const stream = calls[0][0];
+    const bytes = await readStream(stream);
+
+    expect(bytes.length).toBeGreaterThan(0);
+  });
+
+  test("the Readable stream wraps a valid POSIX tar archive with a Dockerfile entry", async () => {
+    const { docker, buildImage } = makeMockDocker();
+    await buildCustomImage(docker, "python", ["numpy", "pandas"], "isol8:python-test");
+
+    const calls = buildImage.mock.calls as unknown as [Readable, unknown][];
+    const tarBytes = await readStream(calls[0][0]);
+
+    // Must be able to extract the Dockerfile from the tar without throwing
+    const dockerfile = extractFromTar(tarBytes, "Dockerfile").toString("utf-8");
+    expect(dockerfile).toContain("FROM isol8:python");
+    expect(dockerfile).toContain("numpy");
+    expect(dockerfile).toContain("pandas");
+  });
+
+  test.each([
+    "python",
+    "node",
+    "bun",
+    "bash",
+  ] as const)("Dockerfile in tar uses correct install command for runtime: %s", async (runtime) => {
+    const { docker, buildImage } = makeMockDocker();
+    await buildCustomImage(docker, runtime, ["mypkg"], `isol8:${runtime}-custom`);
+
+    const calls = buildImage.mock.calls as unknown as [Readable, unknown][];
+    const dockerfile = extractFromTar(await readStream(calls[0][0]), "Dockerfile").toString(
+      "utf-8"
+    );
+
+    const expectedFragments: Record<string, string> = {
+      python: "pip install",
+      node: "npm install",
+      bun: "bun install",
+      bash: "apk add",
+    };
+    expect(dockerfile).toContain(expectedFragments[runtime]);
+    expect(dockerfile).toContain("mypkg");
+  });
+});
+
+// ─── buildCustomImage: build options ─────────────────────────────────────────
+
+describe("buildCustomImage — options passed to docker.buildImage", () => {
+  test("passes the tag string verbatim in options.t", async () => {
+    const { docker, buildImage } = makeMockDocker();
+    const tag = "my-company/python-data-stack:v2";
+    await buildCustomImage(docker, "python", ["numpy"], tag);
+
+    const calls = buildImage.mock.calls as unknown as [unknown, { t: string }][];
+    expect(calls[0][1].t).toBe(tag);
+  });
+
+  test("options.t is set for every runtime so the image is always tagged", async () => {
+    for (const runtime of ["python", "node", "bun", "bash"] as const) {
+      const { docker, buildImage } = makeMockDocker();
+      const tag = `isol8:${runtime}-custom-xyz`;
+      await buildCustomImage(docker, runtime, ["pkg"], tag);
+
+      const calls = buildImage.mock.calls as unknown as [unknown, { t: string }][];
+      expect(calls[0][1].t).toBe(tag);
+    }
+  });
+
+  test("options.dockerfile is set to 'Dockerfile'", async () => {
+    const { docker, buildImage } = makeMockDocker();
+    await buildCustomImage(docker, "python", ["numpy"], "tag");
+
+    const calls = buildImage.mock.calls as unknown as [unknown, { dockerfile: string }][];
+    expect(calls[0][1].dockerfile).toBe("Dockerfile");
+  });
+
+  test("required labels are present in options.labels", async () => {
+    const { docker, buildImage } = makeMockDocker();
+    await buildCustomImage(docker, "python", ["numpy", "pandas"], "tag");
+
+    const calls = buildImage.mock.calls as unknown as [
+      unknown,
+      { labels: Record<string, string> },
+    ][];
+    const labels = calls[0][1].labels;
+
+    expect(labels["org.isol8.deps.hash"]).toBeTruthy();
+    expect(labels["org.isol8.runtime"]).toBe("python");
+    expect(labels["org.isol8.dependencies"]).toBe("numpy,pandas");
+  });
+
+  test("deps hash in labels is deterministic for the same inputs", async () => {
+    const { docker: d1, buildImage: b1 } = makeMockDocker();
+    const { docker: d2, buildImage: b2 } = makeMockDocker();
+
+    await buildCustomImage(d1, "python", ["requests", "numpy"], "tag1");
+    await buildCustomImage(d2, "python", ["numpy", "requests"], "tag2"); // different order
+
+    const getHash = (b: typeof b1) => {
+      const calls = b.mock.calls as unknown as [unknown, { labels: Record<string, string> }][];
+      return calls[0][1].labels["org.isol8.deps.hash"];
+    };
+
+    // normalizePackages sorts, so hash must be the same regardless of input order
+    expect(getHash(b1)).toBe(getHash(b2));
+  });
+
+  test("deps hash changes when packages change", async () => {
+    const { docker: d1, buildImage: b1 } = makeMockDocker();
+    const { docker: d2, buildImage: b2 } = makeMockDocker();
+
+    await buildCustomImage(d1, "python", ["numpy"], "tag1");
+    await buildCustomImage(d2, "python", ["numpy", "pandas"], "tag2");
+
+    const getHash = (b: typeof b1) => {
+      const calls = b.mock.calls as unknown as [unknown, { labels: Record<string, string> }][];
+      return calls[0][1].labels["org.isol8.deps.hash"];
+    };
+
+    expect(getHash(b1)).not.toBe(getHash(b2));
+  });
+
+  test("deps hash changes when runtime changes (same packages)", async () => {
+    const { docker: d1, buildImage: b1 } = makeMockDocker();
+    const { docker: d2, buildImage: b2 } = makeMockDocker();
+
+    await buildCustomImage(d1, "python", ["requests"], "tag1");
+    await buildCustomImage(d2, "node", ["requests"], "tag2");
+
+    const getHash = (b: typeof b1) => {
+      const calls = b.mock.calls as unknown as [unknown, { labels: Record<string, string> }][];
+      return calls[0][1].labels["org.isol8.deps.hash"];
+    };
+
+    expect(getHash(b1)).not.toBe(getHash(b2));
+  });
+});
+
+// ─── buildCustomImage: cache skip ────────────────────────────────────────────
+
+describe("buildCustomImage — cache skip (no build when up to date)", () => {
+  test("skips buildImage when image already has matching deps hash", async () => {
+    // We need to produce the real hash for ["numpy"] + python to set up the mock
+    // We do a build first with force=true to capture the hash, then re-run without force.
+    const capturedHashes: string[] = [];
+    const captureDocker = {
+      buildImage: mock((_stream: any, opts: any) => {
+        capturedHashes.push(opts.labels["org.isol8.deps.hash"]);
+        return Promise.resolve({ on: () => {}, pipe: (d: any) => d });
+      }),
+      modem: {
+        followProgress: mock((_s: any, cb: (e: any, r: any) => void) => cb(null, [])),
+      },
+      getImage: () => ({ inspect: async () => ({}), remove: async () => {} }),
+    } as any;
+
+    // Force build to capture the real hash
+    await buildCustomImage(captureDocker, "python", ["numpy"], "tag", undefined, true);
+    const realHash = capturedHashes[0];
+    expect(realHash).toBeTruthy();
+
+    // Now build a docker mock whose image already has that exact hash
+    const skipBuildImage = mock(() => Promise.resolve({ on: () => {}, pipe: (d: any) => d }));
+    const skipDocker = {
+      buildImage: skipBuildImage,
+      modem: {
+        followProgress: mock((_s: any, cb: (e: any, r: any) => void) => cb(null, [])),
+      },
+      getImage: () => ({
+        inspect: async () => ({
+          Id: "sha256:cached",
+          Config: { Labels: { "org.isol8.deps.hash": realHash } },
+        }),
+        remove: async () => {},
+      }),
+    } as any;
+
+    // Without force, should skip the build entirely
+    await buildCustomImage(skipDocker, "python", ["numpy"], "tag", undefined, false);
+    expect(skipBuildImage).not.toHaveBeenCalled();
+  });
+
+  test("does not skip buildImage when force=true even if hash matches", async () => {
+    const { docker, buildImage } = makeMockDocker({
+      inspectResult: {
+        Id: "sha256:existing",
+        Config: { Labels: { "org.isol8.deps.hash": "any-hash-value" } },
+      },
+    });
+
+    await buildCustomImage(docker, "python", ["numpy"], "tag", undefined, true);
+    expect(buildImage).toHaveBeenCalled();
+  });
+
+  test("does not skip when image does not exist (inspect throws)", async () => {
+    const buildImage = mock(() => Promise.resolve({ on: () => {}, pipe: (d: any) => d }));
+    const docker = {
+      buildImage,
+      modem: {
+        followProgress: mock((_s: any, cb: (e: any, r: any) => void) => cb(null, [])),
+      },
+      getImage: () => ({
+        inspect: async () => {
+          throw new Error("No such image");
+        },
+        remove: async () => {},
+      }),
+    } as any;
+
+    await buildCustomImage(docker, "python", ["numpy"], "tag", undefined, false);
+    expect(buildImage).toHaveBeenCalled();
+  });
+});
+
+// ─── buildCustomImage: error propagation ─────────────────────────────────────
+
+describe("buildCustomImage — error propagation", () => {
+  test("rejects when docker.buildImage rejects", async () => {
+    const docker = {
+      buildImage: mock(() => Promise.reject(new Error("daemon unavailable"))),
+      modem: { followProgress: mock(() => {}) },
+      getImage: () => ({ inspect: async () => ({}), remove: async () => {} }),
+    } as any;
+
+    await expect(buildCustomImage(docker, "python", ["numpy"], "tag")).rejects.toThrow(
+      "daemon unavailable"
     );
   });
 
-  test("throws error for malicious node package name", async () => {
-    expect(buildCustomImage(mockDocker, "node", ["lodash && echo 'pwnd'"], "tag")).rejects.toThrow(
+  test("rejects when followProgress reports an error via callback", async () => {
+    const docker = {
+      buildImage: mock(() => Promise.resolve({ on: () => {}, pipe: (d: any) => d })),
+      modem: {
+        followProgress: mock((_s: any, cb: (e: any, r: any) => void) =>
+          cb(new Error("build failed"), null)
+        ),
+      },
+      getImage: () => ({ inspect: async () => ({}), remove: async () => {} }),
+    } as any;
+
+    await expect(buildCustomImage(docker, "python", ["numpy"], "tag")).rejects.toThrow(
+      "build failed"
+    );
+  });
+
+  test("rejects when final stream event contains an error field", async () => {
+    const docker = {
+      buildImage: mock(() => Promise.resolve({ on: () => {}, pipe: (d: any) => d })),
+      modem: {
+        followProgress: mock((_s: any, cb: (e: any, r: any) => void) =>
+          cb(null, [{ stream: "Step 1/1" }, { error: "no space left on device" }])
+        ),
+      },
+      getImage: () => ({ inspect: async () => ({}), remove: async () => {} }),
+    } as any;
+
+    await expect(buildCustomImage(docker, "python", ["numpy"], "tag")).rejects.toThrow(
+      "no space left on device"
+    );
+  });
+
+  test("throws for unknown runtime before calling docker.buildImage", async () => {
+    const { docker, buildImage } = makeMockDocker();
+
+    await expect(buildCustomImage(docker, "ruby" as any, ["rails"], "tag")).rejects.toThrow(
+      /Unknown runtime/
+    );
+
+    expect(buildImage).not.toHaveBeenCalled();
+  });
+
+  test("throws for invalid package names before calling docker.buildImage", async () => {
+    const { docker, buildImage } = makeMockDocker();
+
+    await expect(buildCustomImage(docker, "python", ["numpy; rm -rf /"], "tag")).rejects.toThrow(
       /Invalid package name/
     );
+
+    expect(buildImage).not.toHaveBeenCalled();
+  });
+
+  test("throws for malicious node package name before calling docker.buildImage", async () => {
+    const { docker, buildImage } = makeMockDocker();
+
+    await expect(buildCustomImage(docker, "node", ["lodash && echo pwnd"], "tag")).rejects.toThrow(
+      /Invalid package name/
+    );
+
+    expect(buildImage).not.toHaveBeenCalled();
+  });
+});
+
+// ─── buildCustomImage: old behaviour tests (kept) ────────────────────────────
+
+describe("image-builder", () => {
+  beforeEach(() => {
+    mockBuildImage.mockClear();
+    mockFollowProgress.mockClear();
   });
 
   test("allows valid version specifiers", async () => {
@@ -60,39 +412,6 @@ describe("image-builder", () => {
   });
 
   describe("smart build - skips when up to date", () => {
-    test("skips building when image exists with matching hash", async () => {
-      // Create a mock Docker where the image exists with matching labels
-      const existingImageId = "sha256:abc123";
-      const dockerHash = "testdockerhash123456";
-
-      const mockDockerWithLabels = {
-        buildImage: mockBuildImage,
-        modem: { followProgress: mockFollowProgress },
-        getImage: () => ({
-          inspect: async () => ({
-            Id: existingImageId,
-            Config: {
-              Labels: {
-                "org.isol8.build.hash": dockerHash,
-              },
-            },
-          }),
-        }),
-      } as any;
-
-      // Without force flag, if image exists with matching hash, build should be skipped
-      // Since we can't mock the hash, we test that with force=true it does build
-      await buildCustomImage(
-        mockDockerWithLabels,
-        "python",
-        ["numpy"],
-        existingImageId,
-        undefined,
-        true
-      );
-      expect(mockBuildImage).toHaveBeenCalled();
-    });
-
     test("builds when force flag is true", async () => {
       await buildCustomImage(mockDocker, "python", ["numpy"], "tag", undefined, true);
       expect(mockBuildImage).toHaveBeenCalled();
@@ -173,6 +492,131 @@ describe("hash functions", () => {
     const bunHash = createHash("sha256").update("bun").update(packages.join("")).digest("hex");
 
     expect(nodeHash).not.toBe(bunHash);
+  });
+});
+
+// ─── buildCustomImage — build log in error messages (Issue 3) ────────────────
+
+describe("buildCustomImage — build log included in error messages", () => {
+  test("error message includes build log when followProgress errors via callback", async () => {
+    const docker = {
+      buildImage: mock(() => Promise.resolve({ on: () => {}, pipe: (d: any) => d })),
+      modem: {
+        followProgress: mock((_s: any, cb: (e: any, r: any) => void, onEvent: (e: any) => void) => {
+          onEvent({ stream: "Step 1/2 : FROM isol8:python\n" });
+          onEvent({ stream: "Step 2/2 : RUN pip install numpy\n" });
+          onEvent({
+            error: "The command '/bin/sh -c pip install numpy' returned a non-zero code: 1",
+          });
+          cb(new Error("build context error"), null);
+        }),
+      },
+      getImage: () => ({ inspect: async () => ({}), remove: async () => {} }),
+    } as any;
+
+    const err = await buildCustomImage(docker, "python", ["numpy"], "tag").catch((e) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.message).toContain("build context error");
+    expect(err.message).toContain("Step 1/2");
+    expect(err.message).toContain("Step 2/2");
+  });
+
+  test("error message includes build log when final event has error field", async () => {
+    const docker = {
+      buildImage: mock(() => Promise.resolve({ on: () => {}, pipe: (d: any) => d })),
+      modem: {
+        followProgress: mock((_s: any, cb: (e: any, r: any) => void, onEvent: (e: any) => void) => {
+          onEvent({ stream: "Step 1/2 : FROM isol8:python\n" });
+          onEvent({ stream: "Step 2/2 : RUN pip install broken-pkg\n" });
+          cb(null, [
+            { stream: "Step 1/2 : FROM isol8:python\n" },
+            { stream: "Step 2/2 : RUN pip install broken-pkg\n" },
+            { error: "ERROR: Could not find a version that satisfies the requirement broken-pkg" },
+          ]);
+        }),
+      },
+      getImage: () => ({ inspect: async () => ({}), remove: async () => {} }),
+    } as any;
+
+    const err = await buildCustomImage(docker, "python", ["broken-pkg"], "tag").catch((e) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.message).toContain("Could not find a version");
+    expect(err.message).toContain("Step 1/2");
+    expect(err.message).toContain("Step 2/2");
+  });
+
+  test("error message has no build log section when no stream events were emitted", async () => {
+    const docker = {
+      buildImage: mock(() => Promise.resolve({ on: () => {}, pipe: (d: any) => d })),
+      modem: {
+        followProgress: mock(
+          (_s: any, cb: (e: any, r: any) => void, _onEvent: (e: any) => void) => {
+            cb(new Error("daemon unavailable"), null);
+          }
+        ),
+      },
+      getImage: () => ({ inspect: async () => ({}), remove: async () => {} }),
+    } as any;
+
+    const err = await buildCustomImage(docker, "python", ["numpy"], "tag").catch((e) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.message).toContain("daemon unavailable");
+    expect(err.message).not.toContain("build log");
+  });
+});
+
+// ─── buildBaseImages — build log in error messages (Issue 3) ─────────────────
+
+describe("buildBaseImages — build log included in error messages", () => {
+  test("error message includes accumulated build log on failure", async () => {
+    const docker = {
+      buildImage: mock(() => Promise.resolve({ on: () => {}, pipe: (d: any) => d })),
+      modem: {
+        followProgress: mock((_s: any, cb: (e: any, r: any) => void, onEvent: (e: any) => void) => {
+          onEvent({ stream: "Step 1/3 : FROM alpine:3.21\n" });
+          onEvent({ stream: "Step 2/3 : RUN apk add python3\n" });
+          onEvent({ stream: "fetch https://dl-cdn.alpinelinux.org/\n" });
+          cb(new Error("network timeout"), null);
+        }),
+      },
+      getImage: () => ({
+        inspect: async () => {
+          throw new Error("No such image");
+        },
+        remove: async () => {},
+      }),
+    } as any;
+
+    const err = await buildBaseImages(docker, undefined, true, ["python"]).catch((e) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.message).toContain("network timeout");
+    expect(err.message).toContain("Step 1/3");
+    expect(err.message).toContain("Step 2/3");
+    expect(err.message).toContain("fetch https://dl-cdn.alpinelinux.org/");
+  });
+
+  test("error message has no build log section when stream emits nothing", async () => {
+    const docker = {
+      buildImage: mock(() => Promise.resolve({ on: () => {}, pipe: (d: any) => d })),
+      modem: {
+        followProgress: mock(
+          (_s: any, cb: (e: any, r: any) => void, _onEvent: (e: any) => void) => {
+            cb(new Error("daemon not running"), null);
+          }
+        ),
+      },
+      getImage: () => ({
+        inspect: async () => {
+          throw new Error("No such image");
+        },
+        remove: async () => {},
+      }),
+    } as any;
+
+    const err = await buildBaseImages(docker, undefined, true, ["python"]).catch((e) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.message).toContain("daemon not running");
+    expect(err.message).not.toContain("build log");
   });
 });
 
@@ -294,5 +738,45 @@ describe("buildCustomImage with setupScript", () => {
     const callArgs = mockBuildImageForSetup.mock.calls[0];
     const opts = callArgs[1];
     expect(opts.labels["org.isol8.setup"]).toBe(script);
+  });
+});
+
+// ─── buildCustomImage: tar content with setupScript ──────────────────────────
+
+describe("buildCustomImage — Dockerfile content in tar stream", () => {
+  test("setup script is baked into Dockerfile in the tar", async () => {
+    const { docker, buildImage } = makeMockDocker();
+    const script = "export MY_VAR=hello";
+    await buildCustomImage(docker, "python", ["numpy"], "tag", undefined, true, script);
+
+    const calls = buildImage.mock.calls as unknown as [Readable, unknown][];
+    const dockerfile = extractFromTar(await readStream(calls[0][0]), "Dockerfile").toString(
+      "utf-8"
+    );
+
+    expect(dockerfile).toContain(".isol8-setup.sh");
+    expect(dockerfile).toContain("chmod +x");
+  });
+
+  test("Dockerfile in tar still uses a Readable stream when setupScript is provided", async () => {
+    const { docker, buildImage } = makeMockDocker();
+    await buildCustomImage(docker, "python", ["numpy"], "tag", undefined, true, "echo hi");
+
+    const calls = buildImage.mock.calls as unknown as [unknown, unknown][];
+    expect(calls[0][0]).toBeInstanceOf(Readable);
+    expect(Buffer.isBuffer(calls[0][0])).toBe(false);
+  });
+
+  test("Dockerfile in tar FROM line matches the runtime passed in", async () => {
+    for (const runtime of ["python", "node", "bun", "bash"] as const) {
+      const { docker, buildImage } = makeMockDocker();
+      await buildCustomImage(docker, runtime, ["pkg"], `isol8:${runtime}-custom`);
+
+      const calls = buildImage.mock.calls as unknown as [Readable, unknown][];
+      const dockerfile = extractFromTar(await readStream(calls[0][0]), "Dockerfile").toString(
+        "utf-8"
+      );
+      expect(dockerfile.split("\n")[0]).toBe(`FROM isol8:${runtime}`);
+    }
   });
 });


### PR DESCRIPTION
## Summary

- **Custom image tagging** — fixes config handling for custom Docker image tags per runtime, ensuring user-defined tags are respected during image builds
- **Selective runtime builds** — adds `--only` flag to `isol8 setup` CLI command, allowing users to build Docker images for specific runtimes instead of all at once
- **Python image fix** — switches Python runtime from Alpine to `python:3.12-slim` (Debian) and pins `uid=100/gid=101` to match tmpfs mount permissions, fixing sandbox permission errors
- **Config fixes** — corrects `dependencies` shorthand handling and ensures `process.cwd()` is passed explicitly to `loadConfig` at all call sites
- **Build error logging** — surfaces Docker build logs in error output for easier debugging

## Changes

- `apps/cli/src/cli.ts` — adds `--only` flag to `setup` command for selective runtime builds
- `packages/core/src/engine/image-builder.ts` — custom tag support and improved build error logging
- `packages/core/src/config.ts` — explicit `cwd` at all `loadConfig` call sites, dependencies shorthand fix
- `packages/core/docker/Dockerfile` — Python stage switched to `python:3.12-slim`, pinned sandbox uid/gid
- `packages/core/src/types.ts` — updated types for new config options
- `packages/core/schema/isol8.config.schema.json` — schema updated to reflect config changes
- Tests updated to cover image builder and config changes